### PR TITLE
Added robots command to manage robots

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>python3-git</depend>
+  <depend>python3-libtmux</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/scripts/robots.py
+++ b/scripts/robots.py
@@ -84,7 +84,7 @@ def main():
 
     if remote_pc == "all":
         try:
-            commands = dict(robot.render_commands(command_name))
+            commands = dict(robot.get_shell_commands(command_name))
         except ValueError:
             print_error(
                 f"Command {command_name} not found for any PC on robot {robot_name}!"
@@ -97,9 +97,7 @@ def main():
             )
             exit(1)
         commands = [
-            robot.remote_pcs[remote_pc].render_command(
-                command_name, {"robot": robot_name}
-            )
+            robot.get_shell_command(remote_pc, command_name, {"robot": robot_name})
         ]
     launch_tmux(
         commands,

--- a/scripts/robots.py
+++ b/scripts/robots.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+import argparse
+import argcomplete
+from tuda_workspace_scripts.print import *
+from tuda_workspace_scripts.robots import *
+from tuda_workspace_scripts.tmux import launch_tmux
+
+
+class RobotChoicesCompleter:
+    def __call__(self, **_):
+        return [var for var in load_robots()]
+
+
+class RemotePCChoicesCompleter:
+    def __call__(self, parsed_args, **_):
+        robot_arg = parsed_args.ROBOT[0]
+        try:
+            robot = get_robot(robot_arg)
+            return list(robot.remote_pcs.keys()) + ["all"]
+        except ValueError:
+            return []
+
+
+class RobotCommandCompleter:
+    def __call__(self, parsed_args, **_):
+        commands = set()
+        robot_arg = parsed_args.ROBOT[0]
+        remote_pc_arg = parsed_args.REMOTE_PC[0]
+
+        try:
+            robot = get_robot(robot_arg)
+            for pc in robot.remote_pcs.values():
+                if remote_pc_arg != "all" and pc.name != remote_pc_arg:
+                    continue
+                for command in pc.commands:
+                    commands.add(command.name)
+        except ValueError:
+            pass
+        return list(commands)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    robots = load_robots()
+    robot_arg = parser.add_argument(
+        "ROBOT", nargs=1, choices=robots.keys(), help="The robot to communicate with."
+    )
+    robot_arg.completer = RobotChoicesCompleter()
+    remote_pc_arg = parser.add_argument(
+        "REMOTE_PC", nargs=1, help="The pc(s) to run this command on."
+    )
+    remote_pc_arg.completer = RemotePCChoicesCompleter()
+    command_arg = parser.add_argument(
+        "COMMAND", nargs=1, help="The command to execute."
+    )
+    command_arg.completer = RobotCommandCompleter()
+    parser.add_argument(
+        "--keep_open_duration",
+        type=int,
+        default=5,
+        help="Time in seconds to keep each pane or window open after the command completes. Defaults to 5.",
+    )
+    parser.add_argument(
+        "--use-windows",
+        action="store_true",
+        default=False,
+        help="Use windows instead of panes.",
+    )
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args()
+
+    robot_name = args.ROBOT[0]
+    remote_pc = args.REMOTE_PC[0]
+    command_name = args.COMMAND[0]
+
+    if robot_name not in robots:
+        print_error(f"Robot {robot_name} not found!")
+        exit(1)
+    robot = robots[robot_name]
+    if remote_pc != "all" and remote_pc not in robot.remote_pcs:
+        print_error(f"PC {remote_pc} not found for robot {robot_name}!")
+        exit(1)
+
+    if remote_pc == "all":
+        try:
+            commands = dict(robot.get_commands(command_name))
+        except ValueError:
+            print_error(
+                f"Command {command_name} not found for any PC on robot {robot_name}!"
+            )
+            exit(1)
+    else:
+        if not robot.remote_pcs[remote_pc].has_command(command_name):
+            print_error(
+                f"Command {command_name} not found for PC {remote_pc} on robot {robot_name}!"
+            )
+            exit(1)
+        commands = [robot.remote_pcs[remote_pc].get_command(command_name)]
+    launch_tmux(commands, use_windows=args.use_windows, keep_open_duration=args.keep_open_duration)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Ctrl-C received! Exiting...")
+        exit(0)

--- a/scripts/robots.py
+++ b/scripts/robots.py
@@ -84,7 +84,7 @@ def main():
 
     if remote_pc == "all":
         try:
-            commands = dict(robot.get_commands(command_name))
+            commands = dict(robot.render_commands(command_name))
         except ValueError:
             print_error(
                 f"Command {command_name} not found for any PC on robot {robot_name}!"
@@ -96,8 +96,16 @@ def main():
                 f"Command {command_name} not found for PC {remote_pc} on robot {robot_name}!"
             )
             exit(1)
-        commands = [robot.remote_pcs[remote_pc].get_command(command_name)]
-    launch_tmux(commands, use_windows=args.use_windows, keep_open_duration=args.keep_open_duration)
+        commands = [
+            robot.remote_pcs[remote_pc].render_command(
+                command_name, {"robot": robot_name}
+            )
+        ]
+    launch_tmux(
+        commands,
+        use_windows=args.use_windows,
+        keep_open_duration=args.keep_open_duration,
+    )
 
 
 if __name__ == "__main__":

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -51,7 +51,7 @@ class RemotePC:
         Get the shell command to execute the given command on this remote PC.
         @raises ValueError if the command is not found.
         """
-        base_vars = {"hostname": self.hostname, "user": self.user}
+        base_vars = {"hostname": self.hostname, "pc_name": self.name, "user": self.user}
         base_vars.update(vars)
         for cmd in self.commands:
             if cmd.name == command_name:

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -48,6 +48,8 @@ class RemotePC:
             if cmd.name == command_name:
                 if command_name == "ssh-copy-id":
                     return f"ssh-copy-id {self.user}@{self.hostname}"
+                if command_name == "ssh":
+                    return f"ssh {self.user}@{self.hostname}"
                 return f"ssh -t {self.user}@{self.hostname} '{cmd.get_command().replace("'", "\\'")}'"
         raise ValueError(f"Command {command_name} not found in remote PC {self.name}")
 

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -1,0 +1,152 @@
+from .workspace import get_workspace_root
+import os
+import shutil
+from typing import Any, Generator
+import yaml
+
+# Use the environment variable TUDA_WSS_CONFIG to specify a config file or directory.
+# You can also specify multiple files and directories separated by the os path separator.
+# If not specified, default to WORKSPACE_ROOT/.config/tuda_workspace_scripts.yaml
+ROBOTS_CONFIG_FILE_PATH = os.getenv("TUDA_WSS_ROBOTS", None)
+if ROBOTS_CONFIG_FILE_PATH is None:
+    ROBOTS_CONFIG_FILE_PATH = get_workspace_root()
+    if ROBOTS_CONFIG_FILE_PATH is not None:
+        ROBOTS_CONFIG_FILE_PATH += "/.config/robots.yaml"
+
+
+__CACHE = {}
+
+
+class Command:
+    def __init__(self, name: str, command: str):
+        self.name = name
+        self.command = command
+
+    def get_command(self) -> str:
+        return self.command
+
+
+class RemotePC:
+    def __init__(self, name: str, hostname: str, user: str, commands: list[Command]):
+        self.name = name
+        self.hostname = hostname
+        self.user = user
+        self.commands = commands
+
+    def has_command(self, name: str) -> bool:
+        for cmd in self.commands:
+            if cmd.name == name:
+                return True
+        return
+
+    def get_command(self, command_name: str) -> str:
+        """
+        Get the shell command to execute the given command on this remote PC.
+        @raises ValueError if the command is not found.
+        """
+        if command_name == "ssh-copy-id":
+            return f"ssh-copy-id {self.user}@{self.hostname}"
+        for cmd in self.commands:
+            if cmd.name == command_name:
+                return f"ssh -t {self.user}@{self.hostname} '{cmd.get_command().replace("'", "\\'")}'"
+        raise ValueError(f"Command {command_name} not found in remote PC {self.name}")
+
+
+class Robot:
+    def __init__(self, name: str, remote_pcs: dict[str, RemotePC]):
+        self.name = name
+        self.remote_pcs = remote_pcs
+
+    def get_commands(self, command_name: str) -> Generator[tuple[str, str], None, None]:
+        """
+        Get the shell commands to execute the given command on all remote PCs that support it.
+        @raises ValueError if the command is not found in any remote PC.
+        """
+        if not any([pc.has_command(command_name) for pc in self.remote_pcs.values()]):
+            raise ValueError(f"Command {command_name} not found in any remote PC")
+        for pc in self.remote_pcs.values():
+            if pc.has_command(command_name):
+                yield (pc.name, pc.get_command(command_name))
+
+
+DEFAULT_COMMANDS = [
+    Command("ssh", ""),
+    Command("ssh-copy-id", ""),
+    Command("reboot", "sudo reboot now"),
+    Command("shutdown", "sudo shutdown now"),
+]
+
+
+def _load_robot_from_yaml(name, config: dict[str, Any]) -> Robot:
+    remote_pcs = dict()
+    shared_commands = set(DEFAULT_COMMANDS)
+    if "commands" in config:
+        for command_name in config["commands"]:
+            shared_commands.add(Command(command_name, config["commands"][command_name]))
+    for pc_name in config["remote_pcs"]:
+        pc_config = config["remote_pcs"][pc_name]
+        if "user" not in pc_config:
+            raise ValueError(f"User not specified for remote PC {pc_name}")
+        user = pc_config["user"]
+        hostname = pc_config["hostname"] if "hostname" in pc_config else pc_name
+        commands = set(shared_commands)
+        if "commands" in pc_config:
+            for command_name in pc_config["commands"]:
+                commands.add(Command(command_name, pc_config["commands"][command_name]))
+        remote_pcs[pc_name] = RemotePC(pc_name, hostname, user, list(commands))
+    return Robot(config["name"] if "name" in config else name, remote_pcs)
+
+
+def _load_robot_config_from_file(path: str) -> dict[str, Robot]:
+    if path in __CACHE:
+        return __CACHE[path]
+    robots = {}
+    with open(path, "r") as f:
+        config = yaml.safe_load(f)
+        if "remote_pcs" in config:
+            # It's a robot
+            filename = os.path.basename(path)
+            name = os.path.splitext(filename)[0]
+            return {name: _load_robot_from_yaml(name, config)}
+        # It's multiple robots
+        for name in config:
+            robots[name] = _load_robot_from_yaml(name, config[name])
+    __CACHE[path] = robots
+    return robots
+
+
+def _load_robots_from_dir(path: str) -> dict[str, Robot]:
+    if path in __CACHE:
+        return __CACHE[path]
+    robots: dict = {}
+    for root, _, files in os.walk(path):
+        for file in files:
+            if not file.endswith(".yaml"):
+                continue
+            robots.update(_load_robot_config_from_file(os.path.join(root, file)))
+    __CACHE[path] = robots
+    return robots
+
+
+def load_robots() -> dict[str, Robot]:
+    robots = {}
+    # Split the config file path by the os path separator
+    for path in ROBOTS_CONFIG_FILE_PATH.split(os.pathsep):
+        if not os.path.exists(path):
+            continue
+        if os.path.isdir(path):
+            robots.update(_load_robots_from_dir(path))
+        else:
+            robots.update(_load_robot_config_from_file(path))
+    return robots
+
+
+def get_robot(name: str) -> Robot:
+    """
+    Get a robot by name
+    @raises ValueError if the robot does not exist
+    """
+    robots = load_robots()
+    if name not in robots:
+        raise ValueError(f"Robot {name} not found")
+    return robots[name]

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -37,7 +37,7 @@ class RemotePC:
         for cmd in self.commands:
             if cmd.name == name:
                 return True
-        return
+        return False
 
     def get_command(self, command_name: str) -> str:
         """

--- a/tuda_workspace_scripts/tmux.py
+++ b/tuda_workspace_scripts/tmux.py
@@ -1,0 +1,47 @@
+import libtmux
+
+
+def launch_tmux(
+    commands: dict | list[str],
+    session_name: str | None = None,
+    use_windows: bool = False,
+    keep_open_duration: int | None = 5,
+):
+    """
+    Launch a tmux session and execute the given commands in panes or windows.
+    @param commands: Commands to run in each pane or window.\
+        If a dict is provided, the keys are used as names.
+    @param session_name: Name of the tmux session. Defaults to None.
+    @param use_windows: If True, each command is executed in a separate window;\
+        if False, panes are used. Defaults to False.
+    @param keep_open_duration: Time in seconds to keep each pane or window open after the\
+        command completes. Defaults to 5. Set to None to keep open indefinitely.
+    """
+    server = libtmux.Server()
+    session = server.new_session(session_name=session_name)
+    window = session.attached_window
+    panes = [window.attached_pane]
+    if use_windows:
+        window.name = list(commands.keys())[0] if commands is dict else commands[0]
+        for i in range(1, len(commands)):
+            name = list(commands.keys())[i] if commands is dict else commands[i]
+            panes.append(session.new_window(window_name=name).attached_pane)
+    else:
+        # Arrange panes in a tiled layout (grid)
+        window.window_layout = "tiled"
+        count_commands = len(commands) if isinstance(commands, list) else len(commands.keys())
+        for i in range(count_commands - 1):
+            panes.append(window.split_window())
+
+    
+    shell_commands = commands if isinstance(commands, list) else list(commands.values())
+    for i, command in enumerate(shell_commands):
+        if keep_open_duration is not None:
+            command = f"{command}; sleep {keep_open_duration}; exit"
+        panes[i].select_pane()
+        panes[i].send_keys(command)
+    try:
+        session.attach()
+        session.kill()
+    except:
+        pass


### PR DESCRIPTION
First implementation of robots command loading commands from yaml and launching them in tmux panes or windows.

Examples:
`tuda_wss robots hans all reboot` Would reboot all computers belonging to the robot *hans*.
`tuda_wss robots gretel gretel-main ssh` Would ssh into the *gretel-main* PC of the *gretel* robot.

A config would look as follows:
```
commands: # shared commands for all pcs
  hello: "echo Hello world"
remote_pcs:
  athena-main:
    user: hector
    commands:
      reboot: ~ # Disables the default reboot command for this pc
  athena-jetson:
    user: hector
    commands:
      restart_docker: "sudo systemctl restart docker"
```

Per default the commands `ssh`, `reboot`, `shutdown` and `ssh-copy-id` are available for all robots.
These commands can simply be overridden by specifying the command name key and a new command for a robot or remote pc.
To disable a default command or shared command, you can use the command name and set its value to `~` (None).

You can also specify multiple robots in a single yaml by having the name of the robot as the root keys (none of them can be named `remote_pcs` though :wink:)

Configs are loaded from directories and files specified in the environment variable `TUDA_WSS_ROBOTS`.