### PR TITLE
Add support to step into share directories of binary packages.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,8 +10,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <depend>ament_index_python</depend>
   <depend>python3-git</depend>
+  <depend>python3-jinja2</depend>
   <depend>python3-libtmux</depend>
+  <depend>python3-yaml</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/scripts/autocompletion/cd.bash
+++ b/scripts/autocompletion/cd.bash
@@ -2,10 +2,9 @@
 
 function _tudawss_cd_complete() {
   # Only one argument possible
-  if [ ${#COMP_WORDS[@]} -gt 3 ]; then
-    return 0
+  if [ ${#COMP_WORDS[@]} -eq 3 ]; then
+    COMPREPLY=( $( compgen -W "$(python3 $TUDA_WSS_BASE_SCRIPTS/helpers/get_package_names_in_workspace.py)" -- "$(_get_cword)" ) )
   fi
-  COMPREPLY=( $( compgen -W "$(python3 $TUDA_WSS_BASE_SCRIPTS/helpers/get_package_names_in_workspace.py)" -- "$(_get_cword)" ) )
   return 0
 }
 

--- a/scripts/helpers/get_package_names_in_workspace.py
+++ b/scripts/helpers/get_package_names_in_workspace.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
+from ament_index_python.packages import get_packages_with_prefixes
 from tuda_workspace_scripts.workspace import get_packages_in_workspace
 
 if __name__ == "__main__":
-    print("\n".join(get_packages_in_workspace()))
+    pkgs = set(get_packages_with_prefixes().keys())
+    pkgs.update(get_packages_in_workspace())
+    print("\n".join(pkgs))

--- a/scripts/helpers/get_package_path.py
+++ b/scripts/helpers/get_package_path.py
@@ -15,4 +15,4 @@ if __name__ == "__main__":
     if path is None or realpath(path).startswith(realpath(workspace_root)):
         path = get_package_path(sys.argv[1])
 
-    print(path or None)
+    print(path or "")

--- a/scripts/helpers/get_package_path.py
+++ b/scripts/helpers/get_package_path.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
-from tuda_workspace_scripts.workspace import get_package_path
+from ament_index_python.packages import get_package_share_directory
+from tuda_workspace_scripts.workspace import get_package_path, get_workspace_root
+from os.path import realpath
 import sys
 
 if __name__ == "__main__":
-    print(get_package_path(sys.argv[1]) or "")
+    try:
+        path = get_package_share_directory(sys.argv[1])
+    except:
+        path = None
+
+    # Check if path is in workspace, if so return path to source directory 
+    workspace_root = get_workspace_root()
+    if path is None or realpath(path).startswith(realpath(workspace_root)):
+        path = get_package_path(sys.argv[1])
+
+    print(path or None)

--- a/tuda_workspace_scripts/workspace.py
+++ b/tuda_workspace_scripts/workspace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python33
+#!/usr/bin/env python3
 try:
     from colcon_core.plugin_system import get_package_identification_extensions
 except ImportError:
@@ -9,6 +9,7 @@ import os
 
 def get_workspace_root(directory=None) -> str | None:
     """
+    The workspace root is the directory containing the src, install and build directories.
     :param directory: Directory from which to search the workspace root. If None will try to find from current and if that fails from the COLCON_PREFIX_PATH
     :return: The path to the workspace root or None if no workspace found.
     """


### PR DESCRIPTION
Also, I changed the logic to step to the package path that would be used in the current terminal.

For example, if you have a package in the src directory that has not yet been sourced into the environment, it would step to the binary share path, not the source package.
This can help spot issues where the wrong package is used.