### PR TITLE
Added Pkg and CI Template Creation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>python3-jinja2</depend>
   <depend>python3-libtmux</depend>
   <depend>python3-yaml</depend>
+  <exec_depend>python-copier-pip</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/scripts/create.py
+++ b/scripts/create.py
@@ -9,15 +9,15 @@ from ament_index_python.packages import get_package_share_directory
 try:
     import git
 except ImportError:
-    print(
-        "GitPython is required! Install using 'pip3 install --user gitpython' or 'apt install python3-git'"
-    )
+    print("GitPython is required! Install using 'apt install python3-git'")
     raise
 
 try:
     import copier
 except ImportError:
-    print("GitPython is required! Install using 'pip3 install --user copier'")
+    print(
+        "Copier is required! Install using 'pip3 install copier --break-system-packages'"
+    )
     raise
 
 
@@ -79,28 +79,16 @@ def parseArguments() -> argparse.Namespace:
         "--is-component", action="store_true", default=None, help="Make it a component?"
     )
     parser.add_argument(
-        "--no-is-component", dest="is-component", default=None, action="store_false"
-    )
-    parser.add_argument(
         "--is-lifecycle",
         action="store_true",
         default=None,
         help="Make it a lifecycle node?",
     )
     parser.add_argument(
-        "--no-is-lifecycle", dest="is-lifecycle", default=None, action="store_false"
-    )
-    parser.add_argument(
         "--has-launch-file",
         action="store_true",
         default=None,
         help="Add a launch file?",
-    )
-    parser.add_argument(
-        "--no-has-launch-file",
-        dest="has-launch-file",
-        default=None,
-        action="store_false",
     )
     parser.add_argument(
         "--launch-file-type",
@@ -112,19 +100,10 @@ def parseArguments() -> argparse.Namespace:
         "--has-params", action="store_true", default=None, help="Add parameter loading"
     )
     parser.add_argument(
-        "--no-has-params", dest="has-params", default=None, action="store_false"
-    )
-    parser.add_argument(
         "--has-subscriber", action="store_true", default=None, help="Add a subscriber?"
     )
     parser.add_argument(
-        "--no-has-subscriber", dest="has-subscriber", default=None, action="store_false"
-    )
-    parser.add_argument(
         "--has-publisher", action="store_true", default=None, help="Add a publisher?"
-    )
-    parser.add_argument(
-        "--no-has-publisher", dest="has-publisher", default=None, action="store_false"
     )
     parser.add_argument(
         "--has-service-server",
@@ -133,37 +112,19 @@ def parseArguments() -> argparse.Namespace:
         help="Add a service server?",
     )
     parser.add_argument(
-        "--no-has-service-server",
-        dest="has-service-server",
-        default=None,
-        action="store_false",
-    )
-    parser.add_argument(
         "--has-action-server",
         action="store_true",
         default=None,
         help="Add an action server?",
     )
     parser.add_argument(
-        "--no-has-action-server",
-        dest="has-action-server",
-        default=None,
-        action="store_false",
-    )
-    parser.add_argument(
         "--has-timer", action="store_true", default=None, help="Add a timer callback?"
-    )
-    parser.add_argument(
-        "--no-has-timer", dest="has-timer", default=None, action="store_false"
     )
     parser.add_argument(
         "--auto-shutdown",
         action="store_true",
         default=None,
         help="Automatically shutdown the node after launch (useful in CI/CD)?",
-    )
-    parser.add_argument(
-        "--no-auto-shutdown", dest="auto-shutdown", default=None, action="store_false"
     )
     parser.add_argument(
         "--interface-types",
@@ -188,7 +149,6 @@ def parseArguments() -> argparse.Namespace:
         default=None,
         help="Add pre-commit hook?",
     )
-    # parser.add_argument("--has-docker-ros", action="store_true", default=None, help="Add the docker-ros CI integration?")
 
     argcomplete.autocomplete(parser)
     return parser.parse_args()
@@ -205,7 +165,8 @@ def add_git_config_info(answers):
 
 
 def add_ros_distro(answers):
-    answers["ros_distro"] = os.environ.get("ROS_DISTRO", "jazzy")
+    if os.environ.get("ROS_DISTRO"):
+        answers["ros_distro"] = os.environ.get("ROS_DISTRO")
 
 
 def create(template_pkg_name: str, template_url: str):

--- a/scripts/create.py
+++ b/scripts/create.py
@@ -216,5 +216,5 @@ def create(template_pkg_name: str, template_url: str):
 
 if __name__ == "__main__":
     template_pkg_name = "ros2_pkg_create"
-    template_url = "https://github.com/Joschi3/ros2-pkg-create"
+    template_url = "https://github.com/tu-darmstadt-ros-pkg/ros2-pkg-create.git"
     create(template_pkg_name, template_url)

--- a/scripts/create.py
+++ b/scripts/create.py
@@ -16,7 +16,7 @@ try:
     import copier
 except ImportError:
     print(
-        "Copier is required! Install using 'pip3 install copier --break-system-packages'"
+        "Copier is required! Install using 'pip3 install copier --user --break-system-packages'"
     )
     raise
 
@@ -144,7 +144,7 @@ def parseArguments() -> argparse.Namespace:
         help="CI type",
     )
     parser.add_argument(
-        "--add_pre_commit",
+        "--add-pre-commit",
         action="store_true",
         default=None,
         help="Add pre-commit hook?",

--- a/scripts/create.py
+++ b/scripts/create.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+from tuda_workspace_scripts.workspace import get_workspace_root, PackageChoicesCompleter
+
+import argcomplete
+import argparse
+import os
+from ament_index_python.packages import get_package_share_directory
+
+try:
+    import git
+except ImportError:
+    print(
+        "GitPython is required! Install using 'pip3 install --user gitpython' or 'apt install python3-git'"
+    )
+    raise
+
+try:
+    import copier
+except ImportError:
+    print("GitPython is required! Install using 'pip3 install --user copier'")
+    raise
+
+
+def parseArguments() -> argparse.Namespace:
+
+    parser = argparse.ArgumentParser(
+        description="Creates a ROS 2 package from templates"
+    )
+
+    parser.add_argument(
+        "--template",
+        type=str,
+        default=None,
+        choices=["cpp_pkg", "msgs_pkg", "python_pkg", "ci"],
+        help="Template",
+    )
+    parser.add_argument(
+        "--destination",
+        "-d",
+        type=str,
+        default=None,
+        help="Destination directory (default: <workspace_root>/src/)",
+    )
+    parser.add_argument(
+        "--defaults", action="store_true", help="Use defaults for all options"
+    )
+
+    parser.add_argument("--package-name", type=str, default=None, help="Package name")
+    parser.add_argument("--description", type=str, default=None, help="Description")
+    parser.add_argument("--maintainer", type=str, default=None, help="Maintainer")
+    parser.add_argument(
+        "--maintainer-email", type=str, default=None, help="Maintainer email"
+    )
+    parser.add_argument("--author", type=str, default=None, help="Author")
+    parser.add_argument("--author-email", type=str, default=None, help="Author email")
+    parser.add_argument(
+        "--license",
+        type=str,
+        default=None,
+        choices=[
+            "Apache-2.0",
+            "BSL-1.0",
+            "BSD-2.0",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "GPL-3.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only",
+            "MIT",
+            "MIT-0",
+        ],
+        help="License",
+    )
+    parser.add_argument("--node-name", type=str, default=None, help="Node name")
+    parser.add_argument(
+        "--node-class-name", type=str, default=None, help="Class name of node"
+    )
+    parser.add_argument(
+        "--is-component", action="store_true", default=None, help="Make it a component?"
+    )
+    parser.add_argument(
+        "--no-is-component", dest="is-component", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--is-lifecycle",
+        action="store_true",
+        default=None,
+        help="Make it a lifecycle node?",
+    )
+    parser.add_argument(
+        "--no-is-lifecycle", dest="is-lifecycle", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--has-launch-file",
+        action="store_true",
+        default=None,
+        help="Add a launch file?",
+    )
+    parser.add_argument(
+        "--no-has-launch-file",
+        dest="has-launch-file",
+        default=None,
+        action="store_false",
+    )
+    parser.add_argument(
+        "--launch-file-type",
+        type=str,
+        choices=["xml", "py", "yml"],
+        help="Type of launch file",
+    )
+    parser.add_argument(
+        "--has-params", action="store_true", default=None, help="Add parameter loading"
+    )
+    parser.add_argument(
+        "--no-has-params", dest="has-params", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--has-subscriber", action="store_true", default=None, help="Add a subscriber?"
+    )
+    parser.add_argument(
+        "--no-has-subscriber", dest="has-subscriber", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--has-publisher", action="store_true", default=None, help="Add a publisher?"
+    )
+    parser.add_argument(
+        "--no-has-publisher", dest="has-publisher", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--has-service-server",
+        action="store_true",
+        default=None,
+        help="Add a service server?",
+    )
+    parser.add_argument(
+        "--no-has-service-server",
+        dest="has-service-server",
+        default=None,
+        action="store_false",
+    )
+    parser.add_argument(
+        "--has-action-server",
+        action="store_true",
+        default=None,
+        help="Add an action server?",
+    )
+    parser.add_argument(
+        "--no-has-action-server",
+        dest="has-action-server",
+        default=None,
+        action="store_false",
+    )
+    parser.add_argument(
+        "--has-timer", action="store_true", default=None, help="Add a timer callback?"
+    )
+    parser.add_argument(
+        "--no-has-timer", dest="has-timer", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--auto-shutdown",
+        action="store_true",
+        default=None,
+        help="Automatically shutdown the node after launch (useful in CI/CD)?",
+    )
+    parser.add_argument(
+        "--no-auto-shutdown", dest="auto-shutdown", default=None, action="store_false"
+    )
+    parser.add_argument(
+        "--interface-types",
+        type=str,
+        default=None,
+        choices=["Message", "Service", "Action"],
+        help="Interfaces types",
+    )
+    parser.add_argument("--msg-name", type=str, default=None, help="Message name")
+    parser.add_argument("--srv-name", type=str, default=None, help="Service name")
+    parser.add_argument("--action-name", type=str, default=None, help="Action name")
+    parser.add_argument(
+        "--ci-type",
+        type=str,
+        choices=["github", "gitlab"],
+        default=None,
+        help="CI type",
+    )
+    parser.add_argument(
+        "--add_pre_commit",
+        action="store_true",
+        default=None,
+        help="Add pre-commit hook?",
+    )
+    # parser.add_argument("--has-docker-ros", action="store_true", default=None, help="Add the docker-ros CI integration?")
+
+    argcomplete.autocomplete(parser)
+    return parser.parse_args()
+
+
+def add_git_config_info(answers):
+    # add author and maintainer info from git config if not yet set
+    git_config = git.GitConfigParser()
+    git_config.read()
+    if not answers.get("author") or not answers.get("maintainer"):
+        answers["user_name_git"] = git_config.get_value("user", "name")
+    if not answers.get("author_email") or not answers.get("maintainer_email"):
+        answers["user_email_git"] = git_config.get_value("user", "email")
+
+
+def add_ros_distro(answers):
+    answers["ros_distro"] = os.environ.get("ROS_DISTRO", "jazzy")
+
+
+def create(template_pkg_name: str, template_url: str):
+
+    # pass specified arguments as data to copier
+    args = parseArguments()
+    workspace_src = os.path.join(get_workspace_root(), "src")
+
+    # Adapt destination path
+    if args.destination is None:
+        args.destination = workspace_src
+    if not os.path.isabs(args.destination):
+        args.destination = os.path.join(workspace_src, args.destination)
+    print(f"Destination: {args.destination}")
+
+    answers = {k: v for k, v in vars(args).items() if v is not None}
+
+    # add author and maintainer info from git config if not yet set
+    add_git_config_info(answers)
+
+    add_ros_distro(answers)
+
+    # get pkg template location if installed as ros pkg
+    try:
+        template_location = get_package_share_directory(template_pkg_name)
+    except KeyError:
+        print(
+            f"Package '{template_pkg_name}' not found locally. Using remote template."
+        )
+        template_location = template_url
+
+    # run copier
+    try:
+        copier.run_copy(
+            template_location,
+            args.destination,
+            data=answers,
+            defaults=args.defaults,
+            unsafe=True,
+            vcs_ref="HEAD",
+        )
+
+    except copier.CopierAnswersInterrupt:
+        print("Aborted")
+        return
+
+
+if __name__ == "__main__":
+    template_pkg_name = "ros2_pkg_create"
+    template_url = "https://github.com/Joschi3/ros2-pkg-create"
+    create(template_pkg_name, template_url)

--- a/scripts/create.py
+++ b/scripts/create.py
@@ -12,14 +12,6 @@ except ImportError:
     print("GitPython is required! Install using 'apt install python3-git'")
     raise
 
-try:
-    import copier
-except ImportError:
-    print(
-        "Copier is required! Install using 'pip3 install copier --user --break-system-packages'"
-    )
-    raise
-
 
 def parseArguments() -> argparse.Namespace:
 
@@ -169,6 +161,31 @@ def add_ros_distro(answers):
         answers["ros_distro"] = os.environ.get("ROS_DISTRO")
 
 
+def create_from_template(template, destination, answers, defaults):
+    try:
+        import copier
+    except ImportError:
+        print(
+            "Copier is required! Install using 'pip3 install copier --user --break-system-packages'"
+        )
+        raise
+
+    # run copier
+    try:
+        copier.run_copy(
+            template,
+            destination,
+            data=answers,
+            defaults=defaults,
+            unsafe=True,
+            vcs_ref="HEAD",
+        )
+
+    except copier.CopierAnswersInterrupt:
+        print("Aborted")
+        return
+
+
 def create(template_pkg_name: str, template_url: str):
 
     # pass specified arguments as data to copier
@@ -195,21 +212,8 @@ def create(template_pkg_name: str, template_url: str):
             f"Package '{template_pkg_name}' not found locally. Using remote template."
         )
         template_location = template_url
-
-    # run copier
-    try:
-        copier.run_copy(
-            template_location,
-            args.destination,
-            data=answers,
-            defaults=args.defaults,
-            unsafe=True,
-            vcs_ref="HEAD",
-        )
-
-    except copier.CopierAnswersInterrupt:
-        print("Aborted")
-        return
+        
+    create_from_template(template_location, args.destination, answers, args.defaults)
 
 
 if __name__ == "__main__":

--- a/scripts/create.py
+++ b/scripts/create.py
@@ -38,8 +38,8 @@ def parseArguments() -> argparse.Namespace:
         "--destination",
         "-d",
         type=str,
-        default=None,
-        help="Destination directory (default: <workspace_root>/src/)",
+        default=os.getcwd(),
+        help="Destination directory (default: current working directory)",
     )
     parser.add_argument(
         "--defaults", action="store_true", help="Use defaults for all options"
@@ -175,9 +175,7 @@ def create(template_pkg_name: str, template_url: str):
     args = parseArguments()
     workspace_src = os.path.join(get_workspace_root(), "src")
 
-    # Adapt destination path
-    if args.destination is None:
-        args.destination = workspace_src
+    # Adapt relative destination path
     if not os.path.isabs(args.destination):
         args.destination = os.path.join(workspace_src, args.destination)
     print(f"Destination: {args.destination}")


### PR DESCRIPTION
Allows the creation of cpp_pkgs, python_pkgs, and msgs_pkgs using a copier.
Additionally, you can create CI Templates for github and gitlab.

Usage:
-  `hector create ` to create pkgs directly in the workspace src folder
- `hector create -d <repository_name>` to create Pkgs / Continous Integration Pipelines in a repository in the src folder

Copier will lead you through a questionnaire, allowing you to select further options easily.
The author name and email are extracted from the global git config.