### PR TITLE
Add --cmake-clean-cache argument to build

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -53,6 +53,12 @@ if __name__ == "__main__":
         "--clean", default=False, action="store_true", help="Clean before building."
     )
     parser.add_argument(
+        "--cmake-clean-cache",
+        default=False,
+        action="store_true",
+        help="Clean CMake cache before building.",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         default=False,
@@ -100,6 +106,7 @@ if __name__ == "__main__":
                 continue_on_error=args.continue_on_error,
                 build_tests=args.build_tests,
                 verbose=args.verbose,
+                cmake_clean_cache=args.cmake_clean_cache,
             )
         )
     except KeyboardInterrupt:

--- a/tuda_workspace_scripts/build.py
+++ b/tuda_workspace_scripts/build.py
@@ -28,6 +28,7 @@ def build_packages(
     verbose: bool = False,
     build_base: str = "build",
     install_base: str = "install",
+    cmake_clean_cache: bool = False,
 ) -> int:
     os.chdir(workspace_root)
     packages = packages or []
@@ -40,6 +41,8 @@ def build_packages(
         arguments += ["--allow-overriding"] + packages
     if continue_on_error:
         arguments += ["--continue-on-error"]
+    if cmake_clean_cache:
+        arguments += ["--cmake-clean-cache"]
 
     cmake_arguments = []
     if build_type is not None:


### PR DESCRIPTION
If you want to only reset the CMake cache without deleting all the build files, there is a command called --cmake-clean-cache with colcon. This PR adds this to tuda_wss build.