### PR TITLE
Fix wtf deleting symlinks that don't point to a regular file but are valid.

### DIFF
--- a/scripts/hooks/wtf/10.check_for_unclean_links.py
+++ b/scripts/hooks/wtf/10.check_for_unclean_links.py
@@ -4,6 +4,14 @@ from tuda_workspace_scripts.workspace import get_workspace_root
 import os
 
 
+def symlink_target_valid(link_path: str) -> bool:
+    if os.path.isfile(link_path) or os.path.isdir(link_path):
+        return True
+    if os.path.islink(link_path):
+        return symlink_target_valid(os.readlink(link_path))
+    return False
+
+
 def fix() -> int:
     print_header("Checking for unclean links")
     workspace_root = get_workspace_root()
@@ -15,12 +23,12 @@ def fix() -> int:
     for root, dirs, files in os.walk(install_folder):
         for d in dirs:
             link_path = os.path.join(root, d)
-            if os.path.islink(link_path) and not os.path.isdir(os.readlink(link_path)):
+            if os.path.islink(link_path) and not symlink_target_valid(link_path):
                 os.unlink(link_path)
                 cleaned = True
         for f in files:
             link_path = os.path.join(root, f)
-            if os.path.islink(link_path) and not os.path.isfile(os.readlink(link_path)):
+            if os.path.islink(link_path) and not symlink_target_valid(link_path):
                 os.unlink(link_path)
                 cleaned = True
     if cleaned:

--- a/scripts/hooks/wtf/10.check_for_unclean_links.py
+++ b/scripts/hooks/wtf/10.check_for_unclean_links.py
@@ -4,11 +4,17 @@ from tuda_workspace_scripts.workspace import get_workspace_root
 import os
 
 
-def symlink_target_valid(link_path: str) -> bool:
+def symlink_target_valid(link_path: str, visited=None) -> bool:
+    if visited is None:
+        visited = set()
     if os.path.isfile(link_path) or os.path.isdir(link_path):
         return True
     if os.path.islink(link_path):
-        return symlink_target_valid(os.readlink(link_path))
+        if link_path in visited:
+            return False  # Circular symlink detected
+        visited.add(link_path)
+        target_path = os.readlink(link_path)
+        return symlink_target_valid(target_path, visited)
     return False
 
 


### PR DESCRIPTION
Currently, it checks if the target is a regular file or directory, but it could also point to another symlink that points to a regular file.

This changes it to check that the final target exists.