### PR TITLE
Use force to delete branches that are deleted on the remote.

### DIFF
--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -107,7 +107,7 @@ def update(**_) -> bool:
                 + "\nDo you want to delete them?"
             ):
                 for branch in deleted_branches:
-                    repo.delete_head(branch)
+                    repo.delete_head(branch, force=True)
                 print(f"Deleted {len(deleted_branches)} branches.")
 
             return True


### PR DESCRIPTION
Since they are usually squashed when merged, git will falsely complain that the branch is unmerged if we don't use force. 