### PR TITLE
Add support for --ament-cmake-args option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 25.1.0
     hooks:
       - id: black
         name: Black

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -58,6 +58,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Clean CMake cache before building.",
     )
+    ament_cmake_args_arg = parser.add_argument(
+        "--ament-cmake-args",
+        default=None,
+        nargs="+",
+        help="Additional arguments to pass to ament_cmake. Such as VAR=VALUE.",
+    )
     parser.add_argument(
         "--verbose",
         "-v",
@@ -107,6 +113,7 @@ if __name__ == "__main__":
                 build_tests=args.build_tests,
                 verbose=args.verbose,
                 cmake_clean_cache=args.cmake_clean_cache,
+                ament_cmake_args=args.ament_cmake_args,
             )
         )
     except KeyboardInterrupt:

--- a/tuda_workspace_scripts/build.py
+++ b/tuda_workspace_scripts/build.py
@@ -29,6 +29,7 @@ def build_packages(
     build_base: str = "build",
     install_base: str = "install",
     cmake_clean_cache: bool = False,
+    ament_cmake_args: list[str] = None,
 ) -> int:
     os.chdir(workspace_root)
     packages = packages or []
@@ -52,6 +53,10 @@ def build_packages(
     if any(cmake_arguments):
         arguments += ["--cmake-args"] + list(
             map(lambda x: f"' {shlex.quote(x)}'", cmake_arguments)
+        )
+    if ament_cmake_args:
+        arguments += ["--ament-cmake-args"] + list(
+            map(lambda x: f"{"-D" + x}", ament_cmake_args)
         )
     if mixin and len(mixin) > 0:
         arguments += ["--mixin"] + mixin


### PR DESCRIPTION
Main use is for setting cmake varaibles i.e. colcon build --ament-cmake-args -DVAR=VALUE

This is currently uses for python-cmake packages to rebuild the venv manually by setting -DSKIP_VENV=OFF

Syntax for hector build would be:

hector build <pkgs> --ament-cmake-args SKIP_VENV=OFF  ISOLATED=ON ...

Also includes a small ci update.

