### PR TITLE
Add remove command

### DIFF
--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -26,12 +26,11 @@ from tuda_workspace_scripts.print import (
     Colors,
     print_workspace_error,
 )
-from tuda_workspace_scripts.workspace import get_workspace_root
+from tuda_workspace_scripts.workspace import get_workspace_root, get_repos_in_workspace
 from tuda_workspace_scripts.git_utils import (
     launch_subprocess,
     get_remote_head_mainline,
     get_deleted_branch_status,
-    collect_repos,
 )
 
 try:
@@ -98,7 +97,9 @@ def process_repo(repo_path: Path) -> RepoResult:
     """Fetch, optional pull, stale-branch detection - runs in a thread."""
     try:
         # 1. Subprocess Fetch (Side effect: updates refs on disk)
-        fetch = launch_subprocess(["git", "fetch", "--all", "--prune"], cwd=repo_path)
+        fetch = launch_subprocess(
+            ["git", "fetch", "--all", "--prune"], cwd=repo_path, timeout=120
+        )
         fetch_ok = fetch.returncode == 0
 
         # 2. Instantiate GitPython Repo object NOW, after fetch,
@@ -217,7 +218,7 @@ def update(**_) -> bool:
     ws_src = Path(ws_root) / "src"
     print_header(f"Updating every git repo under {ws_src}")
 
-    repos = collect_repos(ws_src)
+    repos = [Path(p) for p in get_repos_in_workspace(ws_root)]
     if not repos:
         print_info("No git repositories found.")
         return True

--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -45,6 +45,9 @@ except ImportError:
 
 
 # RESULT CONTAINER
+# Note: RepoResult is distinct from git_utils.RepoStatus:
+# - RepoStatus: Describes the current state of a repo (for status/remove commands)
+# - RepoResult: Captures the outcome of update operations (fetch/pull results, errors)
 class RepoResult:
     __slots__ = (
         "path",
@@ -303,6 +306,8 @@ def update(**_) -> bool:
             else:
                 if res.stdout.strip():
                     print_info(res.stdout.rstrip())
+        elif res.branch.startswith("detached"):
+            print_info("skipped pull - detached HEAD")
         else:
             print_info("skipped pull - current branch has no upstream")
 

--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -27,11 +27,9 @@ from tuda_workspace_scripts.print import (
     print_workspace_error,
 )
 from tuda_workspace_scripts.workspace import get_workspace_root
-from tuda_workspace_scripts.git_helpers import (
+from tuda_workspace_scripts.git_utils import (
     launch_subprocess,
-    has_commits_not_on_remote,
     get_remote_head_mainline,
-    is_ancestor,
     get_deleted_branch_status,
     collect_repos,
 )

--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -146,7 +146,7 @@ def process_repo(repo_path: Path) -> RepoResult:
                 if upstream_exists:
                     pull_attempted = True
                     pull = launch_subprocess(
-                        ["git", "pull", "--ff-only"], cwd=repo_path
+                        ["git", "pull", "--ff-only"], cwd=repo_path, timeout=120
                     )
                     pull_ok = pull.returncode == 0
                     pull_out = pull.stdout or ""

--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -11,8 +11,6 @@ Update every git repository under the *src* directory of a ROS 2 workspace.
 from __future__ import annotations
 
 import os
-import signal
-import subprocess
 import time
 import shutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -29,6 +27,14 @@ from tuda_workspace_scripts.print import (
     print_workspace_error,
 )
 from tuda_workspace_scripts.workspace import get_workspace_root
+from tuda_workspace_scripts.git_helpers import (
+    launch_subprocess,
+    has_commits_not_on_remote,
+    get_remote_head_mainline,
+    is_ancestor,
+    get_deleted_branch_status,
+    collect_repos,
+)
 
 try:
     import git
@@ -38,164 +44,6 @@ except ImportError:
         "'apt install python3-git'"
     )
     raise
-
-
-# HELPERS
-def launch_subprocess(cmd: list[str] | tuple[str, ...], cwd: str | Path):
-    """
-    Run *cmd* in *cwd*, forwarding Ctrl-C to the child process group.
-    Sets GIT_TERMINAL_PROMPT=0 to prevent hanging on missing credentials.
-    """
-    # Prevent git from hanging by asking for credentials in a background thread
-    env = os.environ.copy()
-    env["GIT_TERMINAL_PROMPT"] = "0"
-
-    # Use Popen to allow proper cleanup on KeyboardInterrupt
-    try:
-        with subprocess.Popen(
-            cmd,
-            cwd=str(cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,  # Sets the child as a new process group leader
-            env=env,
-        ) as process:
-            try:
-                stdout, stderr = process.communicate()
-            except KeyboardInterrupt:
-                # Forward the interrupt to the entire child process group.
-                # Since start_new_session=True, the PGID is the same as the PID.
-                os.killpg(process.pid, signal.SIGINT)
-
-                # Wait briefly for it to exit, otherwise let the context manager kill it
-                try:
-                    process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                raise
-
-            return subprocess.CompletedProcess(
-                process.args, process.returncode, stdout, stderr
-            )
-    except KeyboardInterrupt:
-        raise
-
-
-def _has_commits_not_on_any_remote(repo: git.Repo, branch_name: str) -> bool:
-    """True iff *branch_name* contains commits unknown to **any** remote."""
-    try:
-        cnt = int(
-            repo.git.rev_list("--count", branch_name, "--not", "--remotes").strip()
-            or "0"
-        )
-        return cnt > 0
-    except git.exc.GitCommandError:
-        return False
-
-
-def _remote_head_mainline_ref(repo: git.Repo, remote_name: str) -> str | None:
-    """
-    Resolve the remote's configured mainline via refs/remotes/<remote>/HEAD.
-    Returns a ref like '<remote>/<branch>' (e.g. 'origin/ros2') or None.
-    """
-    head_ref = f"refs/remotes/{remote_name}/HEAD"
-    try:
-        sym = repo.git.symbolic_ref("-q", head_ref).strip()
-        if not sym:
-            return None
-        prefix = f"refs/remotes/{remote_name}/"
-        if sym.startswith(prefix):
-            return f"{remote_name}/{sym[len(prefix):]}"
-        return None
-    except git.exc.GitCommandError:
-        return None
-
-
-def _is_ancestor(repo: git.Repo, ancestor: str, descendant: str) -> bool:
-    """True iff ancestor is reachable from descendant."""
-    try:
-        repo.git.merge_base("--is-ancestor", ancestor, descendant)
-        return True
-    except git.exc.GitCommandError:
-        # If refs are missing or invalid, fail safe (return False)
-        return False
-
-
-def _is_deleted_branch(repo: git.Repo, branch: git.Head) -> tuple[bool, str | None]:
-    """
-    Returns (deletable, warning)
-
-    * deletable → upstream vanished **and** branch is safe to delete:
-      - not the current branch
-      - no commits unknown to any remote
-      - merged into remote's HEAD mainline (if resolvable)
-    * warning   → explanatory message when *not* deletable (None if none).
-    """
-    tracking = branch.tracking_branch()
-    if tracking is None:
-        return False, None
-
-    try:
-        # tracking.remote_name might fail if config is corrupt, handle safely
-        if not tracking.remote_name:
-            return False, None
-
-        remote = repo.remotes[tracking.remote_name]
-
-        # Check if the tracking ref actually exists in the remote's refs (name-based)
-        remote_ref_names = {r.name for r in remote.refs}
-        if tracking.name in remote_ref_names:
-            return False, None
-
-    except (
-        KeyError,
-        IndexError,
-        ValueError,
-        AttributeError,
-        TypeError,
-    ):
-        # Best-effort detection: if remote config is lost or invalid, assume not deletable.
-        if not repo.head.is_detached and branch.name == repo.head.ref.name:
-            warn = (
-                f"Remote '{tracking.remote_name}' for current branch {branch.name} "
-                "does not exist anymore. Skipping deletion."
-            )
-            return False, warn
-        return False, None
-
-    if not repo.head.is_detached and branch.name == repo.head.ref.name:
-        warn = (
-            f"Current branch {branch.name} was deleted on the remote. "
-            "Skipping deletion."
-        )
-        return False, warn
-
-    if _has_commits_not_on_any_remote(repo, branch.name):
-        warn = (
-            f"Branch {branch.name} was deleted on the remote but still has "
-            "commits that are not present on any remote."
-        )
-        return False, warn
-
-    # only delete if merged into remote HEAD mainline
-    mainline = _remote_head_mainline_ref(repo, tracking.remote_name)
-    if mainline is None:
-        warn = (
-            f"Branch {branch.name} was deleted on the remote but remote "
-            f"'{tracking.remote_name}' HEAD mainline could not be resolved. "
-            "Skipping deletion."
-        )
-        return False, warn
-
-    if not _is_ancestor(repo, branch.name, mainline):
-        warn = (
-            f"Branch {branch.name} was deleted on the remote but is not merged into "
-            f"{mainline}. Skipping deletion."
-        )
-        return False, warn
-
-    return True, None
 
 
 # RESULT CONTAINER
@@ -333,7 +181,7 @@ def process_repo(repo_path: Path) -> RepoResult:
                             pass
 
             for br in repo.branches:
-                can_del, warn = _is_deleted_branch(repo, br)
+                can_del, warn = get_deleted_branch_status(repo, br)
                 if can_del:
                     deletable.append(br.name)
                 if warn:
@@ -356,21 +204,6 @@ def process_repo(repo_path: Path) -> RepoResult:
     except Exception as exc:
         # Catch-all to prevent one failing repo from crashing the thread pool
         return RepoResult(repo_path, "?", False, False, False, [], [], "", "", str(exc))
-
-
-# DISCOVERY
-def collect_repos(ws_src: Path) -> list[Path]:
-    """Return absolute paths of *top-level* git repos under ws_src."""
-    repos: list[Path] = []
-    for root, dirs, _ in os.walk(ws_src):
-        root_p = Path(root)
-        git_entry = root_p / ".git"
-
-        # Check for directory (standard repo) OR file (submodule/worktree)
-        if git_entry.is_dir() or git_entry.is_file():
-            repos.append(root_p)
-            dirs[:] = []  # don’t recurse into repo
-    return repos
 
 
 # MAIN
@@ -487,7 +320,7 @@ def update(**_) -> bool:
                     continue
 
                 current_branch = repo.head.ref.name
-                mainline = _remote_head_mainline_ref(repo, res.current_branch_remote)
+                mainline = get_remote_head_mainline(repo, res.current_branch_remote)
 
                 if current_branch and mainline:
                     mainline_local = mainline.split("/", 1)[1]
@@ -520,7 +353,7 @@ def update(**_) -> bool:
 
                             # Now that we're off the stale branch, offer deletion if safe
                             if current_branch in repo.branches:
-                                can_del, warn = _is_deleted_branch(
+                                can_del, warn = get_deleted_branch_status(
                                     repo, repo.branches[current_branch]
                                 )
                                 if warn:

--- a/scripts/hooks/update/50.workspace.py
+++ b/scripts/hooks/update/50.workspace.py
@@ -334,7 +334,9 @@ def update(**_) -> bool:
                     )
                     if confirm(msg):
                         co = launch_subprocess(
-                            ["git", "checkout", mainline_local], cwd=res.path
+                            ["git", "checkout", mainline_local],
+                            cwd=res.path,
+                            timeout=120,
                         )
                         if co.returncode != 0:
                             print_error(f"Failed to checkout {mainline_local}:")
@@ -344,7 +346,9 @@ def update(**_) -> bool:
                         else:
                             # After checkout: pull (ff-only) if upstream exists
                             pull2 = launch_subprocess(
-                                ["git", "pull", "--ff-only"], cwd=res.path
+                                ["git", "pull", "--ff-only"],
+                                cwd=res.path,
+                                timeout=120,
                             )
                             if pull2.returncode != 0:
                                 print_error(f"git pull failed on {mainline_local}:")

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from tuda_workspace_scripts.remove import remove_packages
+from tuda_workspace_scripts.print import print_error, print_workspace_error
+from tuda_workspace_scripts.workspace import (
+    find_package_containing,
+    find_packages_in_directory,
+    get_workspace_root,
+    CombinedPackageReposCompleter,
+)
+from tuda_workspace_scripts.completion import SmartCompletionFinder
+import argparse
+import os
+
+
+if __name__ == "__main__":
+    workspace_root = get_workspace_root()
+    parser = argparse.ArgumentParser(
+        prog="remove", description="Remove packages and their repositories."
+    )
+    packages_arg = parser.add_argument(
+        "packages",
+        nargs="*",
+        help="If specified only these packages or repositories are removed.",
+    )
+    packages_arg.completer = CombinedPackageReposCompleter(workspace_root)
+    parser.add_argument(
+        "--this",
+        default=False,
+        action="store_true",
+        help="Remove the package(s) in the current directory.",
+    )
+
+    completer = SmartCompletionFinder(parser)
+    completer(parser)
+    args = parser.parse_args()
+
+    if workspace_root is None:
+        print_workspace_error()
+        exit(1)
+
+    packages = args.packages or []
+    if args.this:
+        packages = find_packages_in_directory(os.getcwd())
+        if len(packages) == 0:
+            package = find_package_containing(os.getcwd())
+            packages = [package] if package else []
+        if len(packages) == 0:
+            print_error(
+                "No package found in the current directory or containing the current directory!"
+            )
+            exit(1)
+
+    if len(packages) == 0:
+        print_error("No packages specified for removal.")
+        exit(1)
+
+    exit(remove_packages(workspace_root, packages))

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -29,6 +29,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Remove the package(s) in the current directory.",
     )
+    parser.add_argument(
+        "--fetch",
+        default=False,
+        action="store_true",
+        help="Fetch remotes before checking mainline merge state.",
+    )
 
     completer = SmartCompletionFinder(parser)
     completer(parser)
@@ -54,4 +60,4 @@ if __name__ == "__main__":
         print_error("No packages or repositories specified for removal.")
         exit(1)
 
-    exit(remove_packages(workspace_root, items))
+    exit(remove_packages(workspace_root, items, fetch_remotes=args.fetch))

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -17,12 +17,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="remove", description="Remove packages and their repositories."
     )
-    packages_arg = parser.add_argument(
-        "packages",
+    items_arg = parser.add_argument(
+        "items",
         nargs="*",
         help="If specified only these packages or repositories are removed.",
     )
-    packages_arg.completer = CombinedPackageReposCompleter(workspace_root)
+    items_arg.completer = CombinedPackageReposCompleter(workspace_root)
     parser.add_argument(
         "--this",
         default=False,
@@ -38,20 +38,20 @@ if __name__ == "__main__":
         print_workspace_error()
         exit(1)
 
-    packages = args.packages or []
+    items = args.items or []
     if args.this:
-        packages = find_packages_in_directory(os.getcwd())
-        if len(packages) == 0:
+        items = find_packages_in_directory(os.getcwd())
+        if len(items) == 0:
             package = find_package_containing(os.getcwd())
-            packages = [package] if package else []
-        if len(packages) == 0:
+            items = [package] if package else []
+        if len(items) == 0:
             print_error(
                 "No package found in the current directory or containing the current directory!"
             )
             exit(1)
 
-    if len(packages) == 0:
-        print_error("No packages specified for removal.")
+    if len(items) == 0:
+        print_error("No packages or repositories specified for removal.")
         exit(1)
 
-    exit(remove_packages(workspace_root, packages))
+    exit(remove_packages(workspace_root, items))

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         help="Remove the package(s) in the current directory.",
     )
     parser.add_argument(
-        "--fetch",
+        "--no-fetch",
         default=False,
         action="store_true",
         help="Fetch remotes before checking mainline merge state.",
@@ -60,4 +60,4 @@ if __name__ == "__main__":
         print_error("No packages or repositories specified for removal.")
         exit(1)
 
-    exit(remove_packages(workspace_root, items, fetch_remotes=args.fetch))
+    exit(remove_packages(workspace_root, items, fetch_remotes=not args.no_fetch))

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+
+"""
+Remove specified packages and their repositories from the workspace.
+Prompts for confirmation if other packages are present in the same repository.
+Before removal, checks if the repository is dirty (uncommitted changes, unpushed commits, stash entries).
+"""
 from tuda_workspace_scripts.remove import remove_packages
 from tuda_workspace_scripts.print import print_error, print_workspace_error
 from tuda_workspace_scripts.workspace import (

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+# PYTHON_ARGCOMPLETE_OK
 """
 Remove specified packages and their repositories from the workspace.
 Prompts for confirmation if other packages are present in the same repository.

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         "--no-fetch",
         default=False,
         action="store_true",
-        help="Fetch remotes before checking mainline merge state.",
+        help="Do not fetch remotes before checking mainline merge state.",
     )
 
     completer = SmartCompletionFinder(parser)

--- a/scripts/remove.py
+++ b/scripts/remove.py
@@ -50,7 +50,9 @@ if __name__ == "__main__":
         print_workspace_error()
         exit(1)
 
-    items = args.items or []
+    if args.this and args.items:
+        parser.error("--this cannot be combined with positional items")
+
     if args.this:
         items = find_packages_in_directory(os.getcwd())
         if len(items) == 0:
@@ -61,6 +63,8 @@ if __name__ == "__main__":
                 "No package found in the current directory or containing the current directory!"
             )
             exit(1)
+    else:
+        items = args.items
 
     if len(items) == 0:
         print_error("No packages or repositories specified for removal.")

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -30,7 +30,7 @@ def main() -> int:
     # Check workspace root itself if it's a git repo
     if (ws_root / ".git").is_dir():
         print_color(Colors.GREEN, f"Looking for changes in {ws_root}...")
-        print_repo_status(get_repo_status(ws_root, ws_root))
+        print_repo_status(get_repo_status(ws_root, ws_root.parent))
 
     # Scan workspace src directory
     ws_src = ws_root / "src"

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -1,158 +1,49 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
-from tuda_workspace_scripts.print import *
+"""
+Display the status of all git repositories in the workspace.
+
+Uses the git_utils module to collect and display repository status
+including uncommitted changes, unpushed commits, and branch information.
+"""
+from pathlib import Path
+
+from tuda_workspace_scripts.git_utils import (
+    collect_repos,
+    print_repo_status,
+)
+from tuda_workspace_scripts.print import (
+    print_error,
+    print_color,
+    print_workspace_error,
+    Colors,
+)
 from tuda_workspace_scripts.workspace import get_workspace_root
-
-try:
-    import git
-    from git.exc import GitCommandError
-except ImportError:
-    print(
-        "GitPython is required! Install using 'pip3 install --user gitpython' or 'apt install python3-git'"
-    )
-    raise
-import os
-
-
-def print_changes(path, root_path):
-    try:
-        repo = git.Repo(path, search_parent_directories=False)
-    except git.exc.InvalidGitRepositoryError:
-        print_error("Failed to obtain git info for: {}".format(path))
-        return
-    try:
-        stash = repo.git.stash("list")
-        changes = repo.index.diff(None)
-    except GitCommandError as e:
-        if "not a git repository" in e.stderr:
-            return
-        print_error("Failed to obtain changes for {}: {}".format(path, e))
-        return
-    try:
-        # Need to reverse using R=True, otherwise we get the diff from tree to HEAD meaning deleted files are added and vice versa
-        changes += repo.index.diff("HEAD", R=True)
-    except git.BadName as e:
-        pass  # Repo has no HEAD which means it probably also has no branches yet and was just initialized
-
-    # Check branches for uncommited commits and pure local branches
-    uncommited_commits = []
-    local_branches = []
-    deleted_branches = []
-    for branch in repo.branches:
-        if branch.tracking_branch() is None:
-            local_branches.append(branch)
-            continue
-        if not branch.tracking_branch().is_valid():
-            deleted_branches.append(branch)
-            continue
-        try:
-            if any(
-                True for _ in repo.iter_commits("{0}@{{u}}..{0}".format(branch.name))
-            ):
-                uncommited_commits.append(branch)
-        except (git.exc.GitCommandError, Exception) as e:
-            print_error(
-                "{} has error on branch {}: {}".format(path, branch.name, e.message)
-            )
-
-    if (
-        any(repo.untracked_files)
-        or any(stash)
-        or any(uncommited_commits)
-        or any(local_branches)
-        or any(changes)
-    ):
-        if not repo.head.is_valid():
-            branch_name = "unknown"
-        elif repo.head.is_detached:
-            branch_name = f"detached at {repo.head.commit}"
-        else:
-            branch_name = repo.head.ref.name
-        print_info(
-            f"{os.path.relpath(path, root_path)} {Colors.LPURPLE}({branch_name})"
-        )
-        if len(repo.branches) == 0:
-            print_color(Colors.LRED, "  No branches configured upstream.")
-        for branch in uncommited_commits:
-            print_color(Colors.RED, "  Unpushed commits on branch {}!".format(branch))
-        for branch in local_branches:
-            print_color(
-                Colors.LRED, "  Local branch with no remote set up: {}".format(branch)
-            )
-        for branch in deleted_branches:
-            print_color(
-                Colors.LRED,
-                "  Local branch for which remote was deleted: {}".format(branch),
-            )
-        if any(stash):
-            print_color(Colors.LCYAN, "  Stashed changes")
-        for item in changes:
-            if item.change_type.startswith("M"):
-                print_color(Colors.ORANGE, "  Modified: {}".format(item.a_path))
-            elif item.change_type.startswith("D"):
-                print_color(Colors.RED, "  Deleted: {}".format(item.a_path))
-            elif item.change_type.startswith("R"):
-                print_color(
-                    Colors.GREEN, "  Renamed: {} -> {}".format(item.a_path, item.b_path)
-                )
-            elif item.change_type.startswith("A"):
-                print_color(Colors.GREEN, "  Added: {}".format(item.a_path))
-            elif item.change_type.startswith("U"):
-                print_error("  Unmerged: {}".format(item.a_path))
-            elif item.change_type.startswith("C"):
-                print_color(
-                    Colors.GREEN, "  Copied: {} -> {}".format(item.a_path, item.b_path)
-                )
-            elif item.change_type.startswith("T"):
-                print_color(Colors.ORANGE, "  Type changed: {}".format(item.a_path))
-            else:
-                print_color(
-                    Colors.RED,
-                    "  Unhandled change type '{}': {}".format(
-                        item.change_type, item.a_path
-                    ),
-                )
-        if len(repo.untracked_files) < 10:
-            for file in repo.untracked_files:
-                print_color(Colors.LGRAY, "  Untracked: {}".format(file))
-        else:
-            print_color(
-                Colors.LGRAY, "  {} untracked files.".format(len(repo.untracked_files))
-            )
-        print("")
-    elif repo.is_dirty():
-        print_info(path)
-        print_error("  Dirty but I don't know why")
-        print("")
 
 
 def main() -> int:
+    """Main entry point for the status command."""
     ws_root_path = get_workspace_root()
     if ws_root_path is None:
         print_workspace_error()
         return 1
 
-    if os.path.isdir(os.path.join(ws_root_path, ".git")):
-        print_color(Colors.GREEN, "Looking for changes in {}...".format(ws_root_path))
-        print_changes(ws_root_path, None)
+    ws_root = Path(ws_root_path)
 
-    def scan_workspace(path, root_path):
-        if not os.path.isdir(path):
-            return
-        try:
-            subdirs = os.listdir(path)
-        except Exception as e:
-            print_error("Error while scanning '{}'!\nMessage: {}".format(path, str(e)))
-            return
-        if ".git" in subdirs:
-            print_changes(path, root_path)
+    # Check workspace root itself if it's a git repo
+    if (ws_root / ".git").is_dir():
+        print_color(Colors.GREEN, f"Looking for changes in {ws_root}...")
+        print_repo_status(ws_root, ws_root)
 
-        for subdir in sorted(subdirs):
-            scan_workspace(os.path.join(path, subdir), root_path)
+    # Scan workspace src directory
+    ws_src = ws_root / "src"
+    print_color(Colors.GREEN, f"Looking for changes in {ws_src}...")
 
-    ws_src_path = os.path.join(ws_root_path, "src")
-    print_color(Colors.GREEN, "Looking for changes in {}...".format(ws_src_path))
-    scan_workspace(ws_src_path, ws_src_path)
+    # Use helper to collect all repos
+    repos = collect_repos(ws_src)
+    for repo_path in sorted(repos):
+        print_repo_status(repo_path, ws_src)
+
     return 0
 
 

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -8,17 +8,14 @@ including uncommitted changes, unpushed commits, and branch information.
 """
 from pathlib import Path
 
-from tuda_workspace_scripts.git_utils import (
-    collect_repos,
-    print_repo_status,
-)
+from tuda_workspace_scripts.git_utils import get_repo_status, print_repo_status
 from tuda_workspace_scripts.print import (
     print_error,
     print_color,
     print_workspace_error,
     Colors,
 )
-from tuda_workspace_scripts.workspace import get_workspace_root
+from tuda_workspace_scripts.workspace import get_workspace_root, get_repos_in_workspace
 
 
 def main() -> int:
@@ -33,16 +30,16 @@ def main() -> int:
     # Check workspace root itself if it's a git repo
     if (ws_root / ".git").is_dir():
         print_color(Colors.GREEN, f"Looking for changes in {ws_root}...")
-        print_repo_status(ws_root, ws_root)
+        print_repo_status(get_repo_status(ws_root, ws_root))
 
     # Scan workspace src directory
     ws_src = ws_root / "src"
     print_color(Colors.GREEN, f"Looking for changes in {ws_src}...")
 
     # Use helper to collect all repos
-    repos = collect_repos(ws_src)
+    repos = get_repos_in_workspace(str(ws_root))
     for repo_path in sorted(repos):
-        print_repo_status(repo_path, ws_src)
+        print_repo_status(get_repo_status(Path(repo_path), ws_src))
 
     return 0
 

--- a/tuda_workspace_scripts/git_helpers.py
+++ b/tuda_workspace_scripts/git_helpers.py
@@ -1,0 +1,712 @@
+"""
+Git Repository Helper Module.
+
+This module provides reusable functions for git repository management within
+a ROS 2 workspace. It consolidates common git operations used by the update
+and remove scripts.
+
+Key Features:
+    - Mainline branch detection with optional auto-configuration
+    - Repository status collection (dirty state, unpushed commits, etc.)
+    - Branch tracking and merge evidence detection
+    - Safe subprocess execution with timeout handling
+    - Repository discovery within workspace boundaries
+
+Example Usage:
+    >>> from tuda_workspace_scripts.git_helpers import (
+    ...     get_mainline_branch,
+    ...     collect_repo_status,
+    ...     RepoStatus,
+    ... )
+    >>> repo = git.Repo("/path/to/repo")
+    >>> mainline = get_mainline_branch(repo, auto_set=True)
+    >>> status = collect_repo_status(Path("/path/to/repo"), workspace_root)
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+try:
+    import git
+    from git import Repo
+except ImportError as e:
+    raise ImportError(
+        "GitPython is required! Install using 'pip install gitpython' "
+        "or 'apt install python3-git'"
+    ) from e
+
+
+# =============================================================================
+# DATA CLASSES
+# =============================================================================
+
+
+@dataclass
+class RepoStatus:
+    """Structured container for repository status.
+
+    This dataclass holds comprehensive information about a git repository's
+    current state, including local changes, remote synchronization status,
+    and branch information.
+
+    Attributes:
+        rel_path: Repository path relative to workspace root.
+        branch: Current branch name or detached HEAD description.
+        mainline: Detected mainline branch name (e.g., 'main', 'ros2').
+        is_git: Whether the path is a valid git repository.
+        has_changes: Whether there are any uncommitted or unpushed changes.
+        untracked_count: Number of untracked files.
+        stash_count: Number of stash entries.
+        changes_summary: List of human-readable change descriptions.
+        unpushed_branches: Tuples of (branch_name, commit_count) for branches
+            with commits not pushed to remote.
+        local_only_branches: Branch names with no upstream configured.
+        deleted_upstream_branches: Tuples of (branch_name, merge_hint) for
+            branches whose upstream was deleted.
+        is_clean: Whether the repository is in a clean state.
+    """
+
+    rel_path: str
+    branch: str
+    mainline: str = "unknown"
+    is_git: bool = False
+
+    # Local changes / risks
+    has_changes: bool = False
+    untracked_count: int = 0
+    stash_count: int = 0
+    changes_summary: List[str] = field(default_factory=list)
+
+    # Remote synchronization (only meaningful if fetch was performed)
+    unpushed_branches: List[Tuple[str, int]] = field(default_factory=list)
+    local_only_branches: List[str] = field(default_factory=list)
+    deleted_upstream_branches: List[Tuple[str, str]] = field(default_factory=list)
+
+    is_clean: bool = True
+
+
+# =============================================================================
+# SUBPROCESS UTILITIES
+# =============================================================================
+
+
+def launch_subprocess(
+    cmd: list[str] | tuple[str, ...],
+    cwd: str | Path,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    """Run a command in a subprocess with proper signal handling.
+
+    This function executes a command in a new process group, allowing proper
+    cleanup on KeyboardInterrupt. It also disables git credential prompts
+    to prevent hanging in non-interactive contexts.
+
+    Args:
+        cmd: Command and arguments to execute.
+        cwd: Working directory for the command.
+        timeout: Maximum seconds to wait for command completion.
+
+    Returns:
+        CompletedProcess with returncode, stdout, and stderr.
+
+    Raises:
+        KeyboardInterrupt: If the user interrupts execution.
+
+    Example:
+        >>> result = launch_subprocess(["git", "fetch", "--all"], "/path/to/repo")
+        >>> if result.returncode == 0:
+        ...     print("Fetch successful")
+    """
+    # Prevent git from hanging by asking for credentials
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+
+    try:
+        with subprocess.Popen(
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+            env=env,
+        ) as process:
+            try:
+                stdout, stderr = process.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGTERM)
+                process.kill()
+                stdout, stderr = process.communicate()
+                return subprocess.CompletedProcess(
+                    process.args, 1, stdout or "", stderr or "Command timed out"
+                )
+            except KeyboardInterrupt:
+                os.killpg(process.pid, signal.SIGINT)
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                raise
+
+            return subprocess.CompletedProcess(
+                process.args, process.returncode, stdout, stderr
+            )
+    except KeyboardInterrupt:
+        raise
+
+
+# =============================================================================
+# REPOSITORY DISCOVERY
+# =============================================================================
+
+
+def get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
+    """Find the git repository root for a path within workspace boundaries.
+
+    This function searches for the git working tree root of the given path,
+    but only returns it if the root is inside the workspace src directory.
+    This prevents accidentally picking up parent repositories (e.g., /home/user).
+
+    Args:
+        path: Path to search from.
+        workspace_src: Workspace src directory (e.g., /workspace/src).
+
+    Returns:
+        The repository root Path if found within workspace, None otherwise.
+
+    Example:
+        >>> repo_root = get_repo_root(
+        ...     Path("/workspace/src/my_pkg/src/file.py"),
+        ...     Path("/workspace/src")
+        ... )
+        >>> print(repo_root)  # /workspace/src/my_pkg
+    """
+    workspace_src = workspace_src.resolve()
+    current = path.resolve()
+
+    # Must be within workspace src
+    if not current.is_relative_to(workspace_src):
+        return None
+
+    try:
+        repo = Repo(current, search_parent_directories=True)
+        repo_root = Path(repo.working_tree_dir).resolve()
+    except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
+        return None
+
+    if repo_root == workspace_src or repo_root.is_relative_to(workspace_src):
+        return repo_root
+
+    return None
+
+
+def collect_repos(ws_src: Path) -> list[Path]:
+    """Discover all top-level git repositories under a workspace src directory.
+
+    Walks the directory tree and identifies git repositories. Does not recurse
+    into found repositories (i.e., nested repos are not returned).
+
+    Args:
+        ws_src: Workspace source directory to search.
+
+    Returns:
+        List of absolute paths to git repository roots.
+
+    Example:
+        >>> repos = collect_repos(Path("/workspace/src"))
+        >>> for repo in repos:
+        ...     print(repo.name)
+    """
+    repos: list[Path] = []
+    for root, dirs, _ in os.walk(ws_src):
+        root_p = Path(root)
+        git_entry = root_p / ".git"
+
+        # Check for directory (standard repo) OR file (submodule/worktree)
+        if git_entry.is_dir() or git_entry.is_file():
+            repos.append(root_p)
+            dirs[:] = []  # Don't recurse into repo
+
+    return repos
+
+
+# =============================================================================
+# MAINLINE DETECTION
+# =============================================================================
+
+
+def get_remote_head_mainline(
+    repo: git.Repo,
+    remote_name: str,
+    auto_set: bool = False,
+) -> str | None:
+    """Resolve the remote's configured mainline branch via refs/remotes/<remote>/HEAD.
+
+    This function checks for a symbolic reference at refs/remotes/<remote>/HEAD
+    which points to the default branch of the remote repository.
+
+    Args:
+        repo: GitPython Repo instance.
+        remote_name: Name of the remote (e.g., 'origin').
+        auto_set: If True and HEAD is not set, attempt to auto-configure it
+            using 'git remote set-head <remote> -a'.
+
+    Returns:
+        Remote ref like '<remote>/<branch>' (e.g., 'origin/ros2'), or None
+        if not resolvable.
+
+    Example:
+        >>> repo = git.Repo("/path/to/repo")
+        >>> mainline_ref = get_remote_head_mainline(repo, "origin", auto_set=True)
+        >>> print(mainline_ref)  # 'origin/main'
+    """
+    head_ref = f"refs/remotes/{remote_name}/HEAD"
+    prefix = f"refs/remotes/{remote_name}/"
+
+    def try_resolve() -> str | None:
+        try:
+            sym = repo.git.symbolic_ref("-q", head_ref).strip()
+            if sym and sym.startswith(prefix):
+                return f"{remote_name}/{sym[len(prefix):]}"
+        except git.exc.GitCommandError:
+            pass
+        return None
+
+    resolved = try_resolve()
+    if resolved:
+        return resolved
+
+    if auto_set:
+        try:
+            subprocess.run(
+                ["git", "remote", "set-head", remote_name, "-a"],
+                cwd=repo.working_tree_dir,
+                capture_output=True,
+                timeout=10,
+            )
+            return try_resolve()
+        except Exception:
+            pass
+
+    return None
+
+
+def get_mainline_branch(repo: git.Repo, auto_set: bool = False) -> str:
+    """Detect the mainline branch name dynamically.
+
+    Attempts to determine the mainline branch using multiple strategies:
+    1. Check remote HEAD symbolic ref (most reliable)
+    2. Look for ROS_DISTRO environment variable as branch name
+    3. Fall back to common names: 'main', 'master'
+
+    Args:
+        repo: GitPython Repo instance.
+        auto_set: If True and remote HEAD is not set, attempt to
+            auto-configure it.
+
+    Returns:
+        The mainline branch name (e.g., 'main', 'ros2', 'master').
+
+    Example:
+        >>> repo = git.Repo("/path/to/repo")
+        >>> mainline = get_mainline_branch(repo, auto_set=True)
+        >>> print(f"Mainline is: {mainline}")
+    """
+    # Strategy 1: Check remote HEAD
+    for remote in repo.remotes:
+        mainline_ref = get_remote_head_mainline(repo, remote.name, auto_set=auto_set)
+        if mainline_ref:
+            return mainline_ref.split("/", 1)[1]
+
+    # Strategy 2: Try ROS_DISTRO and common names
+    ros_distro = os.environ.get("ROS_DISTRO", "").lower()
+    for candidate in [ros_distro, "main", "master"]:
+        if candidate and candidate in repo.heads:
+            return candidate
+
+    return "main"
+
+
+# =============================================================================
+# WORKTREE CHANGES
+# =============================================================================
+
+
+def collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
+    """Collect working tree changes using git status.
+
+    Parses git status porcelain output to identify modified, added, deleted,
+    and renamed files.
+
+    Args:
+        repo: GitPython Repo instance.
+
+    Returns:
+        Tuple of (changes_summary, modified_count, untracked_count) where:
+        - changes_summary: List of human-readable change descriptions
+        - modified_count: Number of tracked files with changes
+        - untracked_count: Number of untracked files
+
+    Example:
+        >>> repo = git.Repo("/path/to/repo")
+        >>> changes, modified, untracked = collect_worktree_changes(repo)
+        >>> for change in changes:
+        ...     print(change)
+    """
+    try:
+        out = repo.git.status("--porcelain=v1").splitlines()
+    except git.exc.GitCommandError:
+        out = []
+
+    changes_summary: List[str] = []
+    modified_count = 0
+    untracked_count = 0
+
+    for line in out:
+        if not line:
+            continue
+        if line.startswith("?? "):
+            untracked_count += 1
+            continue
+
+        xy, rest = line[:2], line[3:]
+        modified_count += 1
+
+        if "R" in xy:
+            changes_summary.append(f"Renamed: {rest}")
+        elif "D" in xy:
+            changes_summary.append(f"Deleted: {rest}")
+        elif "A" in xy:
+            changes_summary.append(f"Added: {rest}")
+        else:
+            changes_summary.append(f"Modified: {rest}")
+
+    return changes_summary, modified_count, untracked_count
+
+
+# =============================================================================
+# BRANCH STATUS
+# =============================================================================
+
+
+def has_commits_not_on_remote(repo: git.Repo, branch_name: str) -> bool:
+    """Check if a branch has commits not on any remote.
+
+    Uses git rev-list to count commits that are reachable from the branch
+    but not from any remote tracking branch.
+
+    Args:
+        repo: GitPython Repo instance.
+        branch_name: Name of the branch to check.
+
+    Returns:
+        True if the branch has commits unknown to any remote.
+
+    Example:
+        >>> if has_commits_not_on_remote(repo, "feature-branch"):
+        ...     print("Branch has unpushed commits")
+    """
+    try:
+        cnt = int(
+            repo.git.rev_list("--count", branch_name, "--not", "--remotes").strip()
+            or "0"
+        )
+        return cnt > 0
+    except git.exc.GitCommandError:
+        return False
+
+
+def is_ancestor(repo: git.Repo, ancestor: str, descendant: str) -> bool:
+    """Check if one commit is an ancestor of another.
+
+    Args:
+        repo: GitPython Repo instance.
+        ancestor: Ref or SHA of potential ancestor commit.
+        descendant: Ref or SHA of potential descendant commit.
+
+    Returns:
+        True if ancestor is reachable from descendant.
+
+    Example:
+        >>> if is_ancestor(repo, "feature-branch", "origin/main"):
+        ...     print("Branch is merged into main")
+    """
+    try:
+        repo.git.merge_base("--is-ancestor", ancestor, descendant)
+        return True
+    except git.exc.GitCommandError:
+        return False
+
+
+def find_merge_evidence(
+    repo: git.Repo,
+    branch: git.Head,
+    mainline: str,
+) -> Tuple[bool, str]:
+    """Detect if a branch has been merged into the mainline.
+
+    Checks for merge evidence using two strategies:
+    1. Direct ancestry (branch is reachable from mainline)
+    2. Squash merge detection (commit message contains branch name)
+
+    Args:
+        repo: GitPython Repo instance.
+        branch: Branch to check for merge evidence.
+        mainline: Mainline branch name to check against.
+
+    Returns:
+        Tuple of (is_merged, hint_message) where:
+        - is_merged: True if merge evidence was found
+        - hint_message: Human-readable description of merge status
+
+    Example:
+        >>> merged, hint = find_merge_evidence(repo, repo.heads["feature"], "main")
+        >>> if merged:
+        ...     print(f"Branch was {hint}")
+    """
+    try:
+        local_mainline = repo.heads[mainline]
+        tracking_ref = local_mainline.tracking_branch()
+        target = tracking_ref.name if tracking_ref else mainline
+
+        # Strategy 1: Direct Ancestry
+        if repo.is_ancestor(branch.commit, target):
+            return True, f"merged into {target}"
+
+        # Strategy 2: Squash Merge Search
+        since_date = branch.commit.committed_datetime.isoformat()
+        found = repo.git.log(
+            target,
+            f"--grep={branch.name}",
+            f"--since={since_date}",
+            "--format=%H",
+            "-n",
+            "1",
+        )
+        if found:
+            return True, f"merged into {target} (squashed)"
+
+        return False, f"merge into {target} unverified"
+    except Exception:
+        pass
+
+    return False, f"merge into {mainline} unverified"
+
+
+def get_deleted_branch_status(
+    repo: git.Repo,
+    branch: git.Head,
+) -> Tuple[bool, str | None]:
+    """Check if a branch's upstream was deleted and if it's safe to delete locally.
+
+    A branch is considered safely deletable if:
+    - Its upstream tracking branch no longer exists on the remote
+    - It is not the current branch
+    - It has no commits unknown to any remote
+    - It is merged into the remote's HEAD mainline
+
+    Args:
+        repo: GitPython Repo instance.
+        branch: Local branch to check.
+
+    Returns:
+        Tuple of (deletable, warning) where:
+        - deletable: True if branch can be safely deleted
+        - warning: Explanatory message when not deletable, None otherwise
+
+    Example:
+        >>> deletable, warning = get_deleted_branch_status(repo, branch)
+        >>> if deletable:
+        ...     repo.delete_head(branch, force=True)
+        >>> elif warning:
+        ...     print(warning)
+    """
+    tracking = branch.tracking_branch()
+    if tracking is None:
+        return False, None
+
+    try:
+        if not tracking.remote_name:
+            return False, None
+
+        remote = repo.remotes[tracking.remote_name]
+        remote_ref_names = {r.name for r in remote.refs}
+
+        if tracking.name in remote_ref_names:
+            return False, None
+
+    except (KeyError, IndexError, ValueError, AttributeError, TypeError):
+        if not repo.head.is_detached and branch.name == repo.head.ref.name:
+            warn = (
+                f"Remote '{tracking.remote_name}' for current branch {branch.name} "
+                "does not exist anymore. Skipping deletion."
+            )
+            return False, warn
+        return False, None
+
+    # Check if it's the current branch
+    if not repo.head.is_detached and branch.name == repo.head.ref.name:
+        warn = (
+            f"Current branch {branch.name} was deleted on the remote. "
+            "Skipping deletion."
+        )
+        return False, warn
+
+    # Check for unpushed commits
+    if has_commits_not_on_remote(repo, branch.name):
+        warn = (
+            f"Branch {branch.name} was deleted on the remote but still has "
+            "commits that are not present on any remote."
+        )
+        return False, warn
+
+    # Check if merged into remote HEAD mainline
+    mainline = get_remote_head_mainline(repo, tracking.remote_name)
+    if mainline is None:
+        warn = (
+            f"Branch {branch.name} was deleted on the remote but remote "
+            f"'{tracking.remote_name}' HEAD mainline could not be resolved. "
+            "Skipping deletion."
+        )
+        return False, warn
+
+    if not is_ancestor(repo, branch.name, mainline):
+        warn = (
+            f"Branch {branch.name} was deleted on the remote but is not merged into "
+            f"{mainline}. Skipping deletion."
+        )
+        return False, warn
+
+    return True, None
+
+
+# =============================================================================
+# REPOSITORY STATUS COLLECTION
+# =============================================================================
+
+
+def collect_repo_status(
+    repo_path: Path,
+    workspace_root: Path,
+    fetch: bool = False,
+) -> RepoStatus:
+    """Collect comprehensive status information for a repository.
+
+    Gathers all relevant status information including local changes,
+    branch status, and optionally fetches from remotes to detect
+    synchronization issues.
+
+    Args:
+        repo_path: Absolute path to the repository.
+        workspace_root: Workspace root for relative path calculation.
+        fetch: If True, fetch from all remotes before checking status.
+
+    Returns:
+        RepoStatus dataclass with complete repository state.
+
+    Example:
+        >>> status = collect_repo_status(Path("/workspace/src/my_pkg"), workspace_root)
+        >>> if not status.is_clean:
+        ...     print(f"Repository has changes: {status.changes_summary}")
+    """
+    rel_path = str(repo_path.relative_to(workspace_root))
+
+    try:
+        repo = Repo(repo_path)
+    except git.exc.InvalidGitRepositoryError:
+        return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
+
+    mainline = get_mainline_branch(repo)
+
+    # Determine current branch
+    try:
+        branch_name = (
+            f"detached ({repo.head.commit.hexsha[:7]})"
+            if repo.head.is_detached
+            else repo.active_branch.name
+        )
+    except Exception:
+        branch_name = "unknown"
+
+    # Collect local working tree status
+    changes_summary, mod_count, untracked_count = collect_worktree_changes(repo)
+
+    # Count stashes
+    stash_count = 0
+    try:
+        stash_out = repo.git.stash("list")
+        stash_count = len(stash_out.splitlines()) if stash_out else 0
+    except git.exc.GitCommandError:
+        pass
+
+    unpushed: List[Tuple[str, int]] = []
+    local_only: List[str] = []
+    deleted_upstream: List[Tuple[str, str]] = []
+
+    if fetch:
+        # Fetch with prune
+        try:
+            subprocess.run(
+                ["git", "fetch", "--prune", "--all", "--quiet"],
+                cwd=str(repo_path),
+                capture_output=True,
+                timeout=30,
+            )
+        except Exception:
+            pass  # Fetch failures are handled gracefully
+
+        # Check branch synchronization
+        for branch in repo.branches:
+            tracking = branch.tracking_branch()
+            if not tracking:
+                if branch.name != mainline:
+                    local_only.append(branch.name)
+                continue
+
+            # Verify tracking ref exists
+            try:
+                repo.git.show_ref("--verify", tracking.path, with_exceptions=True)
+            except Exception:
+                _, hint = find_merge_evidence(repo, branch, mainline)
+                deleted_upstream.append((branch.name, hint))
+                continue
+
+            # Check for unpushed commits
+            try:
+                count = int(
+                    repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
+                )
+                if count > 0:
+                    unpushed.append((branch.name, count))
+            except Exception:
+                pass
+
+    has_changes = (
+        mod_count > 0
+        or untracked_count > 0
+        or stash_count > 0
+        or bool(unpushed)
+        or bool(local_only)
+        or bool(deleted_upstream)
+    )
+
+    return RepoStatus(
+        rel_path=rel_path,
+        branch=branch_name,
+        mainline=mainline,
+        is_git=True,
+        has_changes=has_changes,
+        untracked_count=untracked_count,
+        stash_count=stash_count,
+        unpushed_branches=unpushed,
+        local_only_branches=local_only,
+        deleted_upstream_branches=deleted_upstream,
+        changes_summary=changes_summary,
+        is_clean=not has_changes,
+    )

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -2,8 +2,8 @@
 Git Repository Helper Module.
 
 This module provides reusable functions for git repository management within
-a ROS 2 workspace. It consolidates common git operations used by the update
-and remove scripts.
+a ROS 2 workspace. It consolidates common git operations used by e.g. the status, 
+update and remove scripts.
 
 Key Features:
     - Mainline branch detection with optional auto-configuration
@@ -13,7 +13,7 @@ Key Features:
     - Repository discovery within workspace boundaries
 
 Example Usage:
-    >>> from tuda_workspace_scripts.git_helpers import (
+    >>> from tuda_workspace_scripts.git_utils import (
     ...     get_mainline_branch,
     ...     collect_repo_status,
     ...     RepoStatus,
@@ -22,8 +22,6 @@ Example Usage:
     >>> mainline = get_mainline_branch(repo, auto_set=True)
     >>> status = collect_repo_status(Path("/path/to/repo"), workspace_root)
 """
-
-from __future__ import annotations
 
 import os
 import signal
@@ -37,9 +35,15 @@ try:
     from git import Repo
 except ImportError as e:
     raise ImportError(
-        "GitPython is required! Install using 'pip install gitpython' "
-        "or 'apt install python3-git'"
+        "GitPython is required! Install using 'pip3 install --user gitpython' or 'apt install python3-git'"
     ) from e
+
+from tuda_workspace_scripts.print import (
+    print_error,
+    print_info,
+    print_color,
+    Colors,
+)
 
 
 # =============================================================================
@@ -334,63 +338,6 @@ def get_mainline_branch(repo: git.Repo, auto_set: bool = False) -> str:
 
 
 # =============================================================================
-# WORKTREE CHANGES
-# =============================================================================
-
-
-def collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
-    """Collect working tree changes using git status.
-
-    Parses git status porcelain output to identify modified, added, deleted,
-    and renamed files.
-
-    Args:
-        repo: GitPython Repo instance.
-
-    Returns:
-        Tuple of (changes_summary, modified_count, untracked_count) where:
-        - changes_summary: List of human-readable change descriptions
-        - modified_count: Number of tracked files with changes
-        - untracked_count: Number of untracked files
-
-    Example:
-        >>> repo = git.Repo("/path/to/repo")
-        >>> changes, modified, untracked = collect_worktree_changes(repo)
-        >>> for change in changes:
-        ...     print(change)
-    """
-    try:
-        out = repo.git.status("--porcelain=v1").splitlines()
-    except git.exc.GitCommandError:
-        out = []
-
-    changes_summary: List[str] = []
-    modified_count = 0
-    untracked_count = 0
-
-    for line in out:
-        if not line:
-            continue
-        if line.startswith("?? "):
-            untracked_count += 1
-            continue
-
-        xy, rest = line[:2], line[3:]
-        modified_count += 1
-
-        if "R" in xy:
-            changes_summary.append(f"Renamed: {rest}")
-        elif "D" in xy:
-            changes_summary.append(f"Deleted: {rest}")
-        elif "A" in xy:
-            changes_summary.append(f"Added: {rest}")
-        else:
-            changes_summary.append(f"Modified: {rest}")
-
-    return changes_summary, modified_count, untracked_count
-
-
-# =============================================================================
 # BRANCH STATUS
 # =============================================================================
 
@@ -454,6 +401,7 @@ def find_merge_evidence(
     Checks for merge evidence using two strategies:
     1. Direct ancestry (branch is reachable from mainline)
     2. Squash merge detection (commit message contains branch name)
+    3. Squash merge detection (commit messages contain all branch commit titles)
 
     Args:
         repo: GitPython Repo instance.
@@ -479,7 +427,8 @@ def find_merge_evidence(
         if repo.is_ancestor(branch.commit, target):
             return True, f"merged into {target}"
 
-        # Strategy 2: Squash Merge Search
+        # Strategy 2: Squash Merge Search (by branch name)
+        # Find commits on target that mention branch name
         since_date = branch.commit.committed_datetime.isoformat()
         found = repo.git.log(
             target,
@@ -491,6 +440,30 @@ def find_merge_evidence(
         )
         if found:
             return True, f"merged into {target} (squashed)"
+
+        # Strategy 3: Squash Merge Search (by commit contents)
+        # GitHub adds all commit titles to the squash commit message
+        # Find all commits on branch not in target
+        unique_commits = list(repo.iter_commits(f"{target}..{branch.name}"))
+        if unique_commits:
+            # Extract titles, filtering out empty/whitespace-only ones
+            titles = [
+                c.summary.strip()
+                for c in unique_commits
+                if c.summary and c.summary.strip()
+            ]
+
+            if titles:
+                # Search commits in target since branch creation/update
+                for commit in repo.iter_commits(target, since=since_date):
+                    if isinstance(commit.message, bytes):
+                        msg = commit.message.decode("utf-8", "replace")
+                    else:
+                        msg = commit.message
+
+                    # Check if ALL titles are present in this commit's message
+                    if all(title in msg for title in titles):
+                        return True, f"merged into {target} (squashed)"
 
         return False, f"merge into {target} unverified"
     except Exception:
@@ -709,4 +682,214 @@ def collect_repo_status(
         deleted_upstream_branches=deleted_upstream,
         changes_summary=changes_summary,
         is_clean=not has_changes,
+    )
+
+
+# =============================================================================
+# REPOSITORY STATUS PRINTING
+# =============================================================================
+
+
+def print_repo_status(
+    repo_path: Path,
+    root_path: Path,
+    always_print_header: bool = False,
+) -> Optional[RepoStatus]:
+    """Print status information for a single repository.
+
+    Args:
+        repo_path: Absolute path to the repository.
+        root_path: Root path for relative display.
+        always_print_header: If True, print repo header even if clean.
+
+    Returns:
+        RepoStatus if the repository has issues to report (or if forced), None otherwise.
+        Note: logic for returning None is based on 'has_issues', not 'always_print_header'.
+    """
+    try:
+        repo = git.Repo(repo_path, search_parent_directories=False)
+    except git.exc.InvalidGitRepositoryError:
+        print_error(f"Failed to obtain git info for: {repo_path}")
+        return None
+
+    # Collect stash info
+    try:
+        stash = repo.git.stash("list")
+        stash_count = len(stash.splitlines()) if stash else 0
+    except git.exc.GitCommandError as e:
+        if "not a git repository" in e.stderr:
+            return None
+        print_error(f"Failed to obtain changes for {repo_path}: {e}")
+        return None
+    except Exception:
+        stash_count = 0
+
+    # Collect changes using repo.index.diff
+    try:
+        changes = repo.index.diff(None)
+    except git.exc.GitCommandError as e:
+        print_error(f"Failed to obtain changes for {repo_path}: {e}")
+        return None
+
+    try:
+        # Need to reverse using R=True, otherwise we get the diff from tree to HEAD
+        # meaning deleted files are added and vice versa
+        changes += repo.index.diff("HEAD", R=True)
+    except git.BadName as e:
+        pass  # Repo has no HEAD (probably just initialized)
+
+    # Detect mainline branch
+    mainline = get_mainline_branch(repo)
+
+    # Check branches for unpushed commits, local-only, and deleted upstream
+    unpushed_branches: List[Tuple[str, int]] = []
+    local_only_branches: List[str] = []
+    deleted_branches: List[Tuple[str, str]] = []
+
+    for branch in repo.branches:
+        tracking = branch.tracking_branch()
+        if tracking is None:
+            local_only_branches.append(branch.name)
+            continue
+        if not tracking.is_valid():
+            # Check for merge evidence
+            _, hint = find_merge_evidence(repo, branch, mainline)
+            deleted_branches.append((branch.name, hint))
+            continue
+        try:
+            # Count unpushed commits using iter_commits logic
+            if any(
+                True for _ in repo.iter_commits(f"{branch.name}@{{u}}..{branch.name}")
+            ):
+                # To get the count we can use len or rev_list count
+                count = int(
+                    repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
+                )
+                unpushed_branches.append((branch.name, count))
+        except (git.exc.GitCommandError, Exception) as e:
+            error_msg = getattr(e, "message", str(e))
+            print_error(f"{repo_path} has error on branch {branch.name}: {error_msg}")
+
+    # Determine if there's anything to report
+    untracked_count = len(repo.untracked_files)
+
+    has_issues = (
+        untracked_count > 0
+        or stash_count > 0
+        or bool(unpushed_branches)
+        or bool(local_only_branches)
+        or bool(deleted_branches)
+        or bool(changes)
+    )
+
+    if not has_issues and not always_print_header:
+        if repo.is_dirty():
+            print_info(str(repo_path))
+            print_error("  Dirty but I don't know why")
+            print("")
+        return None
+
+    # Determine current branch name
+    if not repo.head.is_valid():
+        branch_name = "unknown"
+    elif repo.head.is_detached:
+        branch_name = f"detached at {repo.head.commit}"
+    else:
+        branch_name = repo.head.ref.name
+
+    # Print header with branch info
+    rel_path = repo_path.relative_to(root_path) if root_path else repo_path
+    print_info(f"{rel_path} {Colors.LPURPLE}({branch_name} | mainline: {mainline})")
+
+    if not has_issues and always_print_header:
+        print_color(Colors.GREEN, "  Clean")
+        print("")
+        return None
+
+    # Print warnings
+    if len(repo.branches) == 0:
+        print_color(Colors.LRED, "  No branches configured upstream.")
+
+    for branch, count in unpushed_branches:
+        commits_str = "commit" if count == 1 else "commits"
+        print_color(
+            Colors.RED,
+            f"  Unpushed commits on branch {branch}! ({count} {commits_str})",
+        )
+
+    for branch in local_only_branches:
+        print_color(Colors.LRED, f"  Local branch with no remote set up: {branch}")
+
+    for branch, hint in deleted_branches:
+        color = Colors.GREEN if "merged" in hint else Colors.LRED
+        print_color(
+            color, f"  Local branch for which remote was deleted: {branch} ({hint})"
+        )
+
+    if stash_count > 0:
+        if stash_count == 1:
+            print_color(Colors.LCYAN, "  Stashed changes")
+        else:
+            print_color(Colors.LCYAN, f"  Stashed changes ({stash_count} entries)")
+
+    # Print file changes with specific colors
+    changes_summary_str: List[str] = []
+
+    for item in changes:
+        if item.change_type.startswith("M"):
+            msg = f"Modified: {item.a_path}"
+            print_color(Colors.ORANGE, f"  {msg}")
+            changes_summary_str.append(msg)
+        elif item.change_type.startswith("D"):
+            msg = f"Deleted: {item.a_path}"
+            print_color(Colors.RED, f"  {msg}")
+            changes_summary_str.append(msg)
+        elif item.change_type.startswith("R"):
+            msg = f"Renamed: {item.a_path} -> {item.b_path}"
+            print_color(Colors.GREEN, f"  {msg}")
+            changes_summary_str.append(msg)
+        elif item.change_type.startswith("A"):
+            msg = f"Added: {item.a_path}"
+            print_color(Colors.GREEN, f"  {msg}")
+            changes_summary_str.append(msg)
+        elif item.change_type.startswith("U"):
+            msg = f"Unmerged: {item.a_path}"
+            print_error(f"  {msg}")
+            changes_summary_str.append(msg)
+        elif item.change_type.startswith("C"):
+            msg = f"Copied: {item.a_path} -> {item.b_path}"
+            print_color(Colors.GREEN, f"  {msg}")
+            changes_summary_str.append(msg)
+        elif item.change_type.startswith("T"):
+            msg = f"Type changed: {item.a_path}"
+            print_color(Colors.ORANGE, f"  {msg}")
+            changes_summary_str.append(msg)
+        else:
+            msg = f"Unhandled change type '{item.change_type}': {item.a_path}"
+            print_color(Colors.RED, f"  {msg}")
+            changes_summary_str.append(msg)
+
+    # Print untracked files
+    if untracked_count > 0:
+        if untracked_count < 10:
+            for file in repo.untracked_files:
+                print_color(Colors.LGRAY, f"  Untracked: {file}")
+        else:
+            print_color(Colors.LGRAY, f"  {untracked_count} untracked files.")
+
+    print("")
+
+    return RepoStatus(
+        rel_path=str(rel_path),
+        branch=branch_name,
+        mainline=mainline,
+        is_git=True,
+        has_changes=has_issues,
+        untracked_count=untracked_count,
+        stash_count=stash_count,
+        unpushed_branches=unpushed_branches,
+        local_only_branches=local_only_branches,
+        deleted_upstream_branches=[(b, "") for b in deleted_branches],
+        changes_summary=changes_summary_str,
+        is_clean=not has_issues,
     )

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -2,12 +2,12 @@
 Git Repository Helper Module.
 
 This module provides reusable functions for git repository management within
-a ROS 2 workspace. It consolidates common git operations used by e.g. the status, 
+a ROS 2 workspace. It consolidates common git operations used by e.g. the status,
 update and remove scripts.
 
 Key Features:
     - Mainline branch detection with optional auto-configuration
-    - Repository status collection (dirty state, unpushed commits, etc.)
+    - Repository status printing (dirty state, unpushed commits, etc.)
     - Branch tracking and merge evidence detection
     - Safe subprocess execution with timeout handling
     - Repository discovery within workspace boundaries
@@ -15,12 +15,11 @@ Key Features:
 Example Usage:
     >>> from tuda_workspace_scripts.git_utils import (
     ...     get_mainline_branch,
-    ...     collect_repo_status,
-    ...     RepoStatus,
+    ...     print_repo_status,
     ... )
     >>> repo = git.Repo("/path/to/repo")
     >>> mainline = get_mainline_branch(repo, auto_set=True)
-    >>> status = collect_repo_status(Path("/path/to/repo"), workspace_root)
+    >>> status = print_repo_status(Path("/path/to/repo"), workspace_root)
 """
 
 import os
@@ -279,7 +278,7 @@ def get_remote_head_mainline(
             if sym and sym.startswith(prefix):
                 return f"{remote_name}/{sym[len(prefix):]}"
         except git.exc.GitCommandError:
-            pass
+            pass  # HEAD ref not configured; fall through to return None
         return None
 
     resolved = try_resolve()
@@ -296,7 +295,7 @@ def get_remote_head_mainline(
             )
             return try_resolve()
         except Exception:
-            pass
+            pass  # Auto-set failed (network, permissions, etc.); fall through
 
     return None
 
@@ -467,7 +466,7 @@ def find_merge_evidence(
 
         return False, f"merge into {target} unverified"
     except Exception:
-        pass
+        pass  # Branch or mainline ref invalid; report as unverified
 
     return False, f"merge into {mainline} unverified"
 
@@ -557,132 +556,6 @@ def get_deleted_branch_status(
         return False, warn
 
     return True, None
-
-
-# =============================================================================
-# REPOSITORY STATUS COLLECTION
-# =============================================================================
-
-
-def collect_repo_status(
-    repo_path: Path,
-    workspace_root: Path,
-    fetch: bool = False,
-) -> RepoStatus:
-    """Collect comprehensive status information for a repository.
-
-    Gathers all relevant status information including local changes,
-    branch status, and optionally fetches from remotes to detect
-    synchronization issues.
-
-    Args:
-        repo_path: Absolute path to the repository.
-        workspace_root: Workspace root for relative path calculation.
-        fetch: If True, fetch from all remotes before checking status.
-
-    Returns:
-        RepoStatus dataclass with complete repository state.
-
-    Example:
-        >>> status = collect_repo_status(Path("/workspace/src/my_pkg"), workspace_root)
-        >>> if not status.is_clean:
-        ...     print(f"Repository has changes: {status.changes_summary}")
-    """
-    rel_path = str(repo_path.relative_to(workspace_root))
-
-    try:
-        repo = Repo(repo_path)
-    except git.exc.InvalidGitRepositoryError:
-        return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
-
-    mainline = get_mainline_branch(repo)
-
-    # Determine current branch
-    try:
-        branch_name = (
-            f"detached ({repo.head.commit.hexsha[:7]})"
-            if repo.head.is_detached
-            else repo.active_branch.name
-        )
-    except Exception:
-        branch_name = "unknown"
-
-    # Collect local working tree status
-    changes_summary, mod_count, untracked_count = collect_worktree_changes(repo)
-
-    # Count stashes
-    stash_count = 0
-    try:
-        stash_out = repo.git.stash("list")
-        stash_count = len(stash_out.splitlines()) if stash_out else 0
-    except git.exc.GitCommandError:
-        pass
-
-    unpushed: List[Tuple[str, int]] = []
-    local_only: List[str] = []
-    deleted_upstream: List[Tuple[str, str]] = []
-
-    if fetch:
-        # Fetch with prune
-        try:
-            subprocess.run(
-                ["git", "fetch", "--prune", "--all", "--quiet"],
-                cwd=str(repo_path),
-                capture_output=True,
-                timeout=30,
-            )
-        except Exception:
-            pass  # Fetch failures are handled gracefully
-
-        # Check branch synchronization
-        for branch in repo.branches:
-            tracking = branch.tracking_branch()
-            if not tracking:
-                if branch.name != mainline:
-                    local_only.append(branch.name)
-                continue
-
-            # Verify tracking ref exists
-            try:
-                repo.git.show_ref("--verify", tracking.path, with_exceptions=True)
-            except Exception:
-                _, hint = find_merge_evidence(repo, branch, mainline)
-                deleted_upstream.append((branch.name, hint))
-                continue
-
-            # Check for unpushed commits
-            try:
-                count = int(
-                    repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
-                )
-                if count > 0:
-                    unpushed.append((branch.name, count))
-            except Exception:
-                pass
-
-    has_changes = (
-        mod_count > 0
-        or untracked_count > 0
-        or stash_count > 0
-        or bool(unpushed)
-        or bool(local_only)
-        or bool(deleted_upstream)
-    )
-
-    return RepoStatus(
-        rel_path=rel_path,
-        branch=branch_name,
-        mainline=mainline,
-        is_git=True,
-        has_changes=has_changes,
-        untracked_count=untracked_count,
-        stash_count=stash_count,
-        unpushed_branches=unpushed,
-        local_only_branches=local_only,
-        deleted_upstream_branches=deleted_upstream,
-        changes_summary=changes_summary,
-        is_clean=not has_changes,
-    )
 
 
 # =============================================================================
@@ -889,7 +762,7 @@ def print_repo_status(
         stash_count=stash_count,
         unpushed_branches=unpushed_branches,
         local_only_branches=local_only_branches,
-        deleted_upstream_branches=[(b, "") for b in deleted_branches],
+        deleted_upstream_branches=deleted_branches,
         changes_summary=changes_summary_str,
         is_clean=not has_issues,
     )

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -372,6 +372,7 @@ def find_merge_evidence(
         since_date = branch.commit.committed_datetime.isoformat()
         candidate_shas = repo.git.log(
             target,
+            "--fixed-strings",
             f"--grep={branch.name}",
             f"--since={since_date}",
             "--format=%H",

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -362,7 +362,7 @@ def find_merge_evidence(
         target = tracking_ref.name if tracking_ref else mainline
 
         # Strategy 1: Direct Ancestry
-        if repo.is_ancestor(branch.commit, target):
+        if is_ancestor(repo, branch.commit.hexsha, target):
             return True, f"merged into {target}"
 
         # Strategy 2: Squash Merge Search (by branch name)

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -449,11 +449,12 @@ def get_deleted_branch_status(
     if tracking is None:
         return False, None
 
-    try:
-        if not tracking.remote_name:
-            return False, None
+    remote_name = getattr(tracking, "remote_name", None)
+    if not remote_name:
+        return False, None
 
-        remote = repo.remotes[tracking.remote_name]
+    try:
+        remote = repo.remotes[remote_name]
         remote_ref_names = {r.name for r in remote.refs}
 
         if tracking.name in remote_ref_names:
@@ -462,7 +463,7 @@ def get_deleted_branch_status(
     except (KeyError, IndexError, ValueError, AttributeError, TypeError):
         if not repo.head.is_detached and branch.name == repo.head.ref.name:
             warn = (
-                f"Remote '{tracking.remote_name}' for current branch {branch.name} "
+                f"Remote '{remote_name}' for current branch {branch.name} "
                 "does not exist anymore. Skipping deletion."
             )
             return False, warn
@@ -485,11 +486,11 @@ def get_deleted_branch_status(
         return False, warn
 
     # Check if merged into remote HEAD mainline
-    mainline = get_remote_head_mainline(repo, tracking.remote_name)
+    mainline = get_remote_head_mainline(repo, remote_name)
     if mainline is None:
         warn = (
             f"Branch {branch.name} was deleted on the remote but remote "
-            f"'{tracking.remote_name}' HEAD mainline could not be resolved. "
+            f"'{remote_name}' HEAD mainline could not be resolved. "
             "Skipping deletion."
         )
         return False, warn

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -397,10 +397,10 @@ def find_merge_evidence(
 ) -> Tuple[bool, str]:
     """Detect if a branch has been merged into the mainline.
 
-    Checks for merge evidence using two strategies:
-    1. Direct ancestry (branch is reachable from mainline)
-    2. Squash merge detection (commit message contains branch name)
-    3. Squash merge detection (commit messages contain all branch commit titles)
+    Checks for merge evidence using multiple strategies:
+    - Direct ancestry: branch is reachable from mainline
+    - Squash merge detection: commit message contains branch name
+    - Squash merge detection: commit messages contain all branch commit titles
 
     Args:
         repo: GitPython Repo instance.
@@ -608,7 +608,7 @@ def print_repo_status(
         # Need to reverse using R=True, otherwise we get the diff from tree to HEAD
         # meaning deleted files are added and vice versa
         changes += repo.index.diff("HEAD", R=True)
-    except git.BadName as e:
+    except git.BadName:
         pass  # Repo has no HEAD (probably just initialized)
 
     # Detect mainline branch
@@ -639,7 +639,7 @@ def print_repo_status(
                     repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
                 )
                 unpushed_branches.append((branch.name, count))
-        except (git.exc.GitCommandError, Exception) as e:
+        except Exception as e:
             error_msg = getattr(e, "message", str(e))
             print_error(f"{repo_path} has error on branch {branch.name}: {error_msg}")
 
@@ -658,7 +658,18 @@ def print_repo_status(
     if not has_issues and not always_print_header:
         if repo.is_dirty():
             print_info(str(repo_path))
-            print_error("  Dirty but I don't know why")
+            print_error("  Dirty but undetected by change analysis:")
+            try:
+                git_status = repo.git.status("--porcelain")
+                if git_status:
+                    for line in git_status.splitlines()[:5]:
+                        print_error(f"    {line}")
+                    if len(git_status.splitlines()) > 5:
+                        print_error(
+                            f"    ... and {len(git_status.splitlines()) - 5} more"
+                        )
+            except Exception:
+                pass
             print("")
         return None
 
@@ -666,7 +677,7 @@ def print_repo_status(
     if not repo.head.is_valid():
         branch_name = "unknown"
     elif repo.head.is_detached:
-        branch_name = f"detached at {repo.head.commit}"
+        branch_name = f"detached@{repo.head.commit.hexsha[:7]}"
     else:
         branch_name = repo.head.ref.name
 
@@ -681,7 +692,7 @@ def print_repo_status(
 
     # Print warnings
     if len(repo.branches) == 0:
-        print_color(Colors.LRED, "  No branches configured upstream.")
+        print_color(Colors.LRED, "  Repository has no local branches.")
 
     for branch, count in unpushed_branches:
         commits_str = "commit" if count == 1 else "commits"

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -29,11 +29,10 @@ import signal
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 try:
     import git
-    from git import Repo
 except ImportError as e:
     raise ImportError(
         "GitPython is required! Install using 'pip3 install --user gitpython' or 'apt install python3-git'"
@@ -76,7 +75,7 @@ class RepoStatus:
         local_only_branches: Branch names with no upstream configured.
         deleted_upstream_branches: Tuples of (branch_name, merge_hint) for
             branches whose upstream was deleted.
-        is_clean: Whether the repository is in a clean state.
+        is_clean: Whether the repository is in a clean state (inverse of has_changes).
     """
 
     rel_path: str
@@ -97,7 +96,10 @@ class RepoStatus:
     local_only_branches: List[str] = field(default_factory=list)
     deleted_upstream_branches: List[Tuple[str, str]] = field(default_factory=list)
 
-    is_clean: bool = True
+    @property
+    def is_clean(self) -> bool:
+        """Whether the repository is in a clean state (inverse of has_changes)."""
+        return not self.has_changes
 
 
 # =============================================================================
@@ -136,38 +138,35 @@ def launch_subprocess(
     env = os.environ.copy()
     env["GIT_TERMINAL_PROMPT"] = "0"
 
-    try:
-        with subprocess.Popen(
-            cmd,
-            cwd=str(cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-            env=env,
-        ) as process:
-            try:
-                stdout, stderr = process.communicate(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGTERM)
-                process.kill()
-                stdout, stderr = process.communicate()
-                return subprocess.CompletedProcess(
-                    process.args, 1, stdout or "", stderr or "Command timed out"
-                )
-            except KeyboardInterrupt:
-                os.killpg(process.pid, signal.SIGINT)
-                try:
-                    process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                raise
-
+    with subprocess.Popen(
+        cmd,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+        env=env,
+    ) as process:
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            process.kill()
+            stdout, stderr = process.communicate()
             return subprocess.CompletedProcess(
-                process.args, process.returncode, stdout, stderr
+                process.args, 1, stdout or "", stderr or "Command timed out"
             )
-    except KeyboardInterrupt:
-        raise
+        except KeyboardInterrupt:
+            os.killpg(process.pid, signal.SIGINT)
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+            raise
+
+        return subprocess.CompletedProcess(
+            process.args, process.returncode, stdout, stderr
+        )
 
 
 # =============================================================================
@@ -175,7 +174,7 @@ def launch_subprocess(
 # =============================================================================
 
 
-def get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
+def get_repo_root(path: Path, workspace_src: Path) -> Path | None:
     """Find the git repository root for a path within workspace boundaries.
 
     This function searches for the git working tree root of the given path,
@@ -204,7 +203,7 @@ def get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
         return None
 
     try:
-        repo = Repo(current, search_parent_directories=True)
+        repo = git.Repo(current, search_parent_directories=True)
         repo_root = Path(repo.working_tree_dir).resolve()
     except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
         return None
@@ -263,10 +262,9 @@ def get_remote_head_mainline(
 
     if auto_set:
         try:
-            subprocess.run(
+            launch_subprocess(
                 ["git", "remote", "set-head", remote_name, "-a"],
                 cwd=repo.working_tree_dir,
-                capture_output=True,
                 timeout=10,
             )
             return try_resolve()
@@ -441,7 +439,7 @@ def find_merge_evidence(
                         return True, f"merged into {target} (squashed)"
 
         return False, f"merge into {target} unverified"
-    except Exception:
+    except (KeyError, IndexError, git.exc.GitCommandError, ValueError):
         pass  # Branch or mainline ref invalid; report as unverified
 
     return False, f"merge into {mainline} unverified"
@@ -535,7 +533,7 @@ def get_deleted_branch_status(
 
 
 # =============================================================================
-# REPOSITORY STATUS PRINTING
+# REPOSITORY STATUS
 # =============================================================================
 
 
@@ -575,9 +573,7 @@ def get_repo_status(
     try:
         stash = repo.git.stash("list")
         stash_count = len(stash.splitlines()) if stash else 0
-    except git.exc.GitCommandError as e:
-        if "not a git repository" in e.stderr:
-            return RepoStatus(rel_path=rel_path, branch=branch_name, is_git=False)
+    except git.exc.GitCommandError:
         return RepoStatus(rel_path=rel_path, branch=branch_name, is_git=False)
     except Exception:
         stash_count = 0
@@ -614,18 +610,14 @@ def get_repo_status(
             deleted_branches.append((branch.name, hint))
             continue
         try:
-            # Count unpushed commits using iter_commits logic
-            if any(
-                True for _ in repo.iter_commits(f"{branch.name}@{{u}}..{branch.name}")
-            ):
-                # To get the count we can use len or rev_list count
-                count = int(
-                    repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
-                )
+            count = int(
+                repo.git.rev_list("--count", f"{tracking.name}..{branch.name}").strip()
+                or "0"
+            )
+            if count > 0:
                 unpushed_branches.append((branch.name, count))
         except Exception as e:
-            error_msg = getattr(e, "message", str(e))
-            print_error(f"{repo_path} has error on branch {branch.name}: {error_msg}")
+            print_error(f"{repo_path} has error on branch {branch.name}: {e}")
 
     # Determine if there's anything to report
     untracked = list(repo.untracked_files)
@@ -637,29 +629,29 @@ def get_repo_status(
         or stash_count > 0
         or bool(unpushed_branches)
         or bool(local_only_branches)
-        or bool(deleted_branches)
+        or any("merged" not in hint for _, hint in deleted_branches)
         or bool(changes)
     )
 
     # Build changes_summary
-    changes_summary_str: List[str] = []
+    changes_summary: List[str] = []
     for item in changes:
         if item.change_type.startswith("M"):
-            changes_summary_str.append(f"Modified: {item.a_path}")
+            changes_summary.append(f"Modified: {item.a_path}")
         elif item.change_type.startswith("D"):
-            changes_summary_str.append(f"Deleted: {item.a_path}")
+            changes_summary.append(f"Deleted: {item.a_path}")
         elif item.change_type.startswith("R"):
-            changes_summary_str.append(f"Renamed: {item.a_path} -> {item.b_path}")
+            changes_summary.append(f"Renamed: {item.a_path} -> {item.b_path}")
         elif item.change_type.startswith("A"):
-            changes_summary_str.append(f"Added: {item.a_path}")
+            changes_summary.append(f"Added: {item.a_path}")
         elif item.change_type.startswith("U"):
-            changes_summary_str.append(f"Unmerged: {item.a_path}")
+            changes_summary.append(f"Unmerged: {item.a_path}")
         elif item.change_type.startswith("C"):
-            changes_summary_str.append(f"Copied: {item.a_path} -> {item.b_path}")
+            changes_summary.append(f"Copied: {item.a_path} -> {item.b_path}")
         elif item.change_type.startswith("T"):
-            changes_summary_str.append(f"Type changed: {item.a_path}")
+            changes_summary.append(f"Type changed: {item.a_path}")
         else:
-            changes_summary_str.append(
+            changes_summary.append(
                 f"Unhandled change type '{item.change_type}': {item.a_path}"
             )
 
@@ -672,12 +664,11 @@ def get_repo_status(
         untracked_count=untracked_count,
         untracked_files=untracked,
         stash_count=stash_count,
-        changes_summary=changes_summary_str,
+        changes_summary=changes_summary,
         has_branches=has_branches,
         unpushed_branches=unpushed_branches,
         local_only_branches=local_only_branches,
         deleted_upstream_branches=deleted_branches,
-        is_clean=not has_issues,
     )
 
 

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -15,11 +15,13 @@ Key Features:
 Example Usage:
     >>> from tuda_workspace_scripts.git_utils import (
     ...     get_mainline_branch,
+    ...     get_repo_status,
     ...     print_repo_status,
     ... )
     >>> repo = git.Repo("/path/to/repo")
     >>> mainline = get_mainline_branch(repo, auto_set=True)
-    >>> status = print_repo_status(Path("/path/to/repo"), workspace_root)
+    >>> status = get_repo_status(Path("/path/to/repo"), workspace_root)
+    >>> print_repo_status(status)
 """
 
 import os
@@ -65,7 +67,9 @@ class RepoStatus:
         is_git: Whether the path is a valid git repository.
         has_changes: Whether there are any uncommitted or unpushed changes.
         untracked_count: Number of untracked files.
+        untracked_files: List of untracked file paths.
         stash_count: Number of stash entries.
+        has_branches: Whether the repository has any local branches.
         changes_summary: List of human-readable change descriptions.
         unpushed_branches: Tuples of (branch_name, commit_count) for branches
             with commits not pushed to remote.
@@ -83,8 +87,10 @@ class RepoStatus:
     # Local changes / risks
     has_changes: bool = False
     untracked_count: int = 0
+    untracked_files: List[str] = field(default_factory=list)
     stash_count: int = 0
     changes_summary: List[str] = field(default_factory=list)
+    has_branches: bool = True
 
     # Remote synchronization (only meaningful if fetch was performed)
     unpushed_branches: List[Tuple[str, int]] = field(default_factory=list)
@@ -207,36 +213,6 @@ def get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
         return repo_root
 
     return None
-
-
-def collect_repos(ws_src: Path) -> list[Path]:
-    """Discover all top-level git repositories under a workspace src directory.
-
-    Walks the directory tree and identifies git repositories. Does not recurse
-    into found repositories (i.e., nested repos are not returned).
-
-    Args:
-        ws_src: Workspace source directory to search.
-
-    Returns:
-        List of absolute paths to git repository roots.
-
-    Example:
-        >>> repos = collect_repos(Path("/workspace/src"))
-        >>> for repo in repos:
-        ...     print(repo.name)
-    """
-    repos: list[Path] = []
-    for root, dirs, _ in os.walk(ws_src):
-        root_p = Path(root)
-        git_entry = root_p / ".git"
-
-        # Check for directory (standard repo) OR file (submodule/worktree)
-        if git_entry.is_dir() or git_entry.is_file():
-            repos.append(root_p)
-            dirs[:] = []  # Don't recurse into repo
-
-    return repos
 
 
 # =============================================================================
@@ -563,27 +539,37 @@ def get_deleted_branch_status(
 # =============================================================================
 
 
-def print_repo_status(
+def get_repo_status(
     repo_path: Path,
     root_path: Path,
-    always_print_header: bool = False,
-) -> Optional[RepoStatus]:
-    """Print status information for a single repository.
+) -> RepoStatus:
+    """Collect status information for a single git repository.
+
+    Pure data collection without any console output. Use print_repo_status()
+    if you also need formatted printing.
 
     Args:
         repo_path: Absolute path to the repository.
-        root_path: Root path for relative display.
-        always_print_header: If True, print repo header even if clean.
+        root_path: Root path for computing relative display path.
 
     Returns:
-        RepoStatus if the repository has issues to report (or if forced), None otherwise.
-        Note: logic for returning None is based on 'has_issues', not 'always_print_header'.
+        RepoStatus with all fields populated. If the path is not a valid
+        git repository, returns a RepoStatus with is_git=False.
     """
+    rel_path = str(repo_path.relative_to(root_path) if root_path else repo_path)
+
     try:
         repo = git.Repo(repo_path, search_parent_directories=False)
     except git.exc.InvalidGitRepositoryError:
-        print_error(f"Failed to obtain git info for: {repo_path}")
-        return None
+        return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
+
+    # Determine current branch name
+    if not repo.head.is_valid():
+        branch_name = "unknown"
+    elif repo.head.is_detached:
+        branch_name = f"detached@{repo.head.commit.hexsha[:7]}"
+    else:
+        branch_name = repo.head.ref.name
 
     # Collect stash info
     try:
@@ -591,18 +577,16 @@ def print_repo_status(
         stash_count = len(stash.splitlines()) if stash else 0
     except git.exc.GitCommandError as e:
         if "not a git repository" in e.stderr:
-            return None
-        print_error(f"Failed to obtain changes for {repo_path}: {e}")
-        return None
+            return RepoStatus(rel_path=rel_path, branch=branch_name, is_git=False)
+        return RepoStatus(rel_path=rel_path, branch=branch_name, is_git=False)
     except Exception:
         stash_count = 0
 
     # Collect changes using repo.index.diff
     try:
         changes = repo.index.diff(None)
-    except git.exc.GitCommandError as e:
-        print_error(f"Failed to obtain changes for {repo_path}: {e}")
-        return None
+    except git.exc.GitCommandError:
+        return RepoStatus(rel_path=rel_path, branch=branch_name, is_git=False)
 
     try:
         # Need to reverse using R=True, otherwise we get the diff from tree to HEAD
@@ -644,7 +628,9 @@ def print_repo_status(
             print_error(f"{repo_path} has error on branch {branch.name}: {error_msg}")
 
     # Determine if there's anything to report
-    untracked_count = len(repo.untracked_files)
+    untracked = list(repo.untracked_files)
+    untracked_count = len(untracked)
+    has_branches = len(repo.branches) > 0
 
     has_issues = (
         untracked_count > 0
@@ -655,125 +641,129 @@ def print_repo_status(
         or bool(changes)
     )
 
-    if not has_issues and not always_print_header:
-        if repo.is_dirty():
-            print_info(str(repo_path))
-            print_error("  Dirty but undetected by change analysis:")
-            try:
-                git_status = repo.git.status("--porcelain")
-                if git_status:
-                    for line in git_status.splitlines()[:5]:
-                        print_error(f"    {line}")
-                    if len(git_status.splitlines()) > 5:
-                        print_error(
-                            f"    ... and {len(git_status.splitlines()) - 5} more"
-                        )
-            except Exception:
-                pass
-            print("")
-        return None
+    # Build changes_summary
+    changes_summary_str: List[str] = []
+    for item in changes:
+        if item.change_type.startswith("M"):
+            changes_summary_str.append(f"Modified: {item.a_path}")
+        elif item.change_type.startswith("D"):
+            changes_summary_str.append(f"Deleted: {item.a_path}")
+        elif item.change_type.startswith("R"):
+            changes_summary_str.append(f"Renamed: {item.a_path} -> {item.b_path}")
+        elif item.change_type.startswith("A"):
+            changes_summary_str.append(f"Added: {item.a_path}")
+        elif item.change_type.startswith("U"):
+            changes_summary_str.append(f"Unmerged: {item.a_path}")
+        elif item.change_type.startswith("C"):
+            changes_summary_str.append(f"Copied: {item.a_path} -> {item.b_path}")
+        elif item.change_type.startswith("T"):
+            changes_summary_str.append(f"Type changed: {item.a_path}")
+        else:
+            changes_summary_str.append(
+                f"Unhandled change type '{item.change_type}': {item.a_path}"
+            )
 
-    # Determine current branch name
-    if not repo.head.is_valid():
-        branch_name = "unknown"
-    elif repo.head.is_detached:
-        branch_name = f"detached@{repo.head.commit.hexsha[:7]}"
-    else:
-        branch_name = repo.head.ref.name
+    return RepoStatus(
+        rel_path=rel_path,
+        branch=branch_name,
+        mainline=mainline,
+        is_git=True,
+        has_changes=has_issues,
+        untracked_count=untracked_count,
+        untracked_files=untracked,
+        stash_count=stash_count,
+        changes_summary=changes_summary_str,
+        has_branches=has_branches,
+        unpushed_branches=unpushed_branches,
+        local_only_branches=local_only_branches,
+        deleted_upstream_branches=deleted_branches,
+        is_clean=not has_issues,
+    )
+
+
+def print_repo_status(
+    status: RepoStatus,
+    always_print_header: bool = False,
+) -> None:
+    """Print formatted status information for a repository.
+
+    Pure display function that takes a RepoStatus from get_repo_status()
+    and prints it with color formatting.
+
+    Args:
+        status: RepoStatus object from get_repo_status().
+        always_print_header: If True, print repo header even when clean.
+    """
+    if not status.is_git:
+        print_error(f"Failed to obtain git info for: {status.rel_path}")
+        return
+
+    if status.is_clean and not always_print_header:
+        return
 
     # Print header with branch info
-    rel_path = repo_path.relative_to(root_path) if root_path else repo_path
-    print_info(f"{rel_path} {Colors.LPURPLE}({branch_name} | mainline: {mainline})")
+    print_info(
+        f"{status.rel_path} {Colors.LPURPLE}({status.branch} | mainline: {status.mainline})"
+    )
 
-    if not has_issues and always_print_header:
+    if status.is_clean:
         print_color(Colors.GREEN, "  Clean")
         print("")
-        return None
+        return
 
     # Print warnings
-    if len(repo.branches) == 0:
+    if not status.has_branches:
         print_color(Colors.LRED, "  Repository has no local branches.")
 
-    for branch, count in unpushed_branches:
+    for branch, count in status.unpushed_branches:
         commits_str = "commit" if count == 1 else "commits"
         print_color(
             Colors.RED,
             f"  Unpushed commits on branch {branch}! ({count} {commits_str})",
         )
 
-    for branch in local_only_branches:
+    for branch in status.local_only_branches:
         print_color(Colors.LRED, f"  Local branch with no remote set up: {branch}")
 
-    for branch, hint in deleted_branches:
+    for branch, hint in status.deleted_upstream_branches:
         color = Colors.GREEN if "merged" in hint else Colors.LRED
         print_color(
             color, f"  Local branch for which remote was deleted: {branch} ({hint})"
         )
 
-    if stash_count > 0:
-        if stash_count == 1:
+    if status.stash_count > 0:
+        if status.stash_count == 1:
             print_color(Colors.LCYAN, "  Stashed changes")
         else:
-            print_color(Colors.LCYAN, f"  Stashed changes ({stash_count} entries)")
+            print_color(
+                Colors.LCYAN, f"  Stashed changes ({status.stash_count} entries)"
+            )
 
     # Print file changes with specific colors
-    changes_summary_str: List[str] = []
-
-    for item in changes:
-        if item.change_type.startswith("M"):
-            msg = f"Modified: {item.a_path}"
-            print_color(Colors.ORANGE, f"  {msg}")
-            changes_summary_str.append(msg)
-        elif item.change_type.startswith("D"):
-            msg = f"Deleted: {item.a_path}"
-            print_color(Colors.RED, f"  {msg}")
-            changes_summary_str.append(msg)
-        elif item.change_type.startswith("R"):
-            msg = f"Renamed: {item.a_path} -> {item.b_path}"
-            print_color(Colors.GREEN, f"  {msg}")
-            changes_summary_str.append(msg)
-        elif item.change_type.startswith("A"):
-            msg = f"Added: {item.a_path}"
-            print_color(Colors.GREEN, f"  {msg}")
-            changes_summary_str.append(msg)
-        elif item.change_type.startswith("U"):
-            msg = f"Unmerged: {item.a_path}"
-            print_error(f"  {msg}")
-            changes_summary_str.append(msg)
-        elif item.change_type.startswith("C"):
-            msg = f"Copied: {item.a_path} -> {item.b_path}"
-            print_color(Colors.GREEN, f"  {msg}")
-            changes_summary_str.append(msg)
-        elif item.change_type.startswith("T"):
-            msg = f"Type changed: {item.a_path}"
-            print_color(Colors.ORANGE, f"  {msg}")
-            changes_summary_str.append(msg)
+    for summary in status.changes_summary:
+        if summary.startswith("Modified:"):
+            print_color(Colors.ORANGE, f"  {summary}")
+        elif summary.startswith("Deleted:"):
+            print_color(Colors.RED, f"  {summary}")
+        elif (
+            summary.startswith("Renamed:")
+            or summary.startswith("Added:")
+            or summary.startswith("Copied:")
+        ):
+            print_color(Colors.GREEN, f"  {summary}")
+        elif summary.startswith("Unmerged:"):
+            print_error(f"  {summary}")
+        elif summary.startswith("Type changed:"):
+            print_color(Colors.ORANGE, f"  {summary}")
         else:
-            msg = f"Unhandled change type '{item.change_type}': {item.a_path}"
-            print_color(Colors.RED, f"  {msg}")
-            changes_summary_str.append(msg)
+            print_color(Colors.RED, f"  {summary}")
 
     # Print untracked files
-    if untracked_count > 0:
-        if untracked_count < 10:
-            for file in repo.untracked_files:
+    if status.untracked_count > 0:
+        if status.untracked_count < 10:
+            for file in status.untracked_files:
                 print_color(Colors.LGRAY, f"  Untracked: {file}")
         else:
-            print_color(Colors.LGRAY, f"  {untracked_count} untracked files.")
+            print_color(Colors.LGRAY, f"  {status.untracked_count} untracked files.")
 
     print("")
-
-    return RepoStatus(
-        rel_path=str(rel_path),
-        branch=branch_name,
-        mainline=mainline,
-        is_git=True,
-        has_changes=has_issues,
-        untracked_count=untracked_count,
-        stash_count=stash_count,
-        unpushed_branches=unpushed_branches,
-        local_only_branches=local_only_branches,
-        deleted_upstream_branches=deleted_branches,
-        changes_summary=changes_summary_str,
-        is_clean=not has_issues,
-    )

--- a/tuda_workspace_scripts/git_utils.py
+++ b/tuda_workspace_scripts/git_utils.py
@@ -6,7 +6,7 @@ a ROS 2 workspace. It consolidates common git operations used by e.g. the status
 update and remove scripts.
 
 Key Features:
-    - Mainline branch detection with optional auto-configuration
+    - Mainline branch detection
     - Repository status printing (dirty state, unpushed commits, etc.)
     - Branch tracking and merge evidence detection
     - Safe subprocess execution with timeout handling
@@ -19,12 +19,13 @@ Example Usage:
     ...     print_repo_status,
     ... )
     >>> repo = git.Repo("/path/to/repo")
-    >>> mainline = get_mainline_branch(repo, auto_set=True)
+    >>> mainline = get_mainline_branch(repo)
     >>> status = get_repo_status(Path("/path/to/repo"), workspace_root)
     >>> print_repo_status(status)
 """
 
 import os
+import re
 import signal
 import subprocess
 from dataclasses import dataclass, field
@@ -100,6 +101,11 @@ class RepoStatus:
     def is_clean(self) -> bool:
         """Whether the repository is in a clean state (inverse of has_changes)."""
         return not self.has_changes
+
+    @property
+    def has_unmerged_deleted_branches(self) -> bool:
+        """Whether any deleted-upstream branch lacks merge evidence into mainline."""
+        return any("merged" not in hint for _, hint in self.deleted_upstream_branches)
 
 
 # =============================================================================
@@ -222,59 +228,29 @@ def get_repo_root(path: Path, workspace_src: Path) -> Path | None:
 def get_remote_head_mainline(
     repo: git.Repo,
     remote_name: str,
-    auto_set: bool = False,
 ) -> str | None:
     """Resolve the remote's configured mainline branch via refs/remotes/<remote>/HEAD.
-
-    This function checks for a symbolic reference at refs/remotes/<remote>/HEAD
-    which points to the default branch of the remote repository.
 
     Args:
         repo: GitPython Repo instance.
         remote_name: Name of the remote (e.g., 'origin').
-        auto_set: If True and HEAD is not set, attempt to auto-configure it
-            using 'git remote set-head <remote> -a'.
 
     Returns:
         Remote ref like '<remote>/<branch>' (e.g., 'origin/ros2'), or None
-        if not resolvable.
-
-    Example:
-        >>> repo = git.Repo("/path/to/repo")
-        >>> mainline_ref = get_remote_head_mainline(repo, "origin", auto_set=True)
-        >>> print(mainline_ref)  # 'origin/main'
+        if refs/remotes/<remote>/HEAD is not configured.
     """
     head_ref = f"refs/remotes/{remote_name}/HEAD"
     prefix = f"refs/remotes/{remote_name}/"
-
-    def try_resolve() -> str | None:
-        try:
-            sym = repo.git.symbolic_ref("-q", head_ref).strip()
-            if sym and sym.startswith(prefix):
-                return f"{remote_name}/{sym[len(prefix):]}"
-        except git.exc.GitCommandError:
-            pass  # HEAD ref not configured; fall through to return None
-        return None
-
-    resolved = try_resolve()
-    if resolved:
-        return resolved
-
-    if auto_set:
-        try:
-            launch_subprocess(
-                ["git", "remote", "set-head", remote_name, "-a"],
-                cwd=repo.working_tree_dir,
-                timeout=10,
-            )
-            return try_resolve()
-        except Exception:
-            pass  # Auto-set failed (network, permissions, etc.); fall through
-
+    try:
+        sym = repo.git.symbolic_ref("-q", head_ref).strip()
+        if sym and sym.startswith(prefix):
+            return f"{remote_name}/{sym[len(prefix):]}"
+    except git.exc.GitCommandError:
+        pass
     return None
 
 
-def get_mainline_branch(repo: git.Repo, auto_set: bool = False) -> str:
+def get_mainline_branch(repo: git.Repo) -> str:
     """Detect the mainline branch name dynamically.
 
     Attempts to determine the mainline branch using multiple strategies:
@@ -282,22 +258,11 @@ def get_mainline_branch(repo: git.Repo, auto_set: bool = False) -> str:
     2. Look for ROS_DISTRO environment variable as branch name
     3. Fall back to common names: 'main', 'master'
 
-    Args:
-        repo: GitPython Repo instance.
-        auto_set: If True and remote HEAD is not set, attempt to
-            auto-configure it.
-
     Returns:
         The mainline branch name (e.g., 'main', 'ros2', 'master').
-
-    Example:
-        >>> repo = git.Repo("/path/to/repo")
-        >>> mainline = get_mainline_branch(repo, auto_set=True)
-        >>> print(f"Mainline is: {mainline}")
     """
-    # Strategy 1: Check remote HEAD
     for remote in repo.remotes:
-        mainline_ref = get_remote_head_mainline(repo, remote.name, auto_set=auto_set)
+        mainline_ref = get_remote_head_mainline(repo, remote.name)
         if mainline_ref:
             return mainline_ref.split("/", 1)[1]
 
@@ -401,18 +366,24 @@ def find_merge_evidence(
             return True, f"merged into {target}"
 
         # Strategy 2: Squash Merge Search (by branch name)
-        # Find commits on target that mention branch name
+        # Use --grep as a coarse prefilter, then verify with a word-boundary
+        # match in Python to avoid false positives when the branch name is a
+        # common substring (e.g. "fix", "test", "ros2").
         since_date = branch.commit.committed_datetime.isoformat()
-        found = repo.git.log(
+        candidate_shas = repo.git.log(
             target,
             f"--grep={branch.name}",
             f"--since={since_date}",
             "--format=%H",
-            "-n",
-            "1",
-        )
-        if found:
-            return True, f"merged into {target} (squashed)"
+        ).splitlines()
+        if candidate_shas:
+            name_pattern = re.compile(rf"\b{re.escape(branch.name)}\b")
+            for sha in candidate_shas:
+                msg = repo.commit(sha).message
+                if isinstance(msg, bytes):
+                    msg = msg.decode("utf-8", "replace")
+                if name_pattern.search(msg):
+                    return True, f"merged into {target} (squashed)"
 
         # Strategy 3: Squash Merge Search (by commit contents)
         # GitHub adds all commit titles to the squash commit message
@@ -616,22 +587,13 @@ def get_repo_status(
             )
             if count > 0:
                 unpushed_branches.append((branch.name, count))
-        except Exception as e:
-            print_error(f"{repo_path} has error on branch {branch.name}: {e}")
+        except git.exc.GitCommandError:
+            pass  # rev-list failed (corrupt refs, etc.); skip count for this branch
 
     # Determine if there's anything to report
     untracked = list(repo.untracked_files)
     untracked_count = len(untracked)
     has_branches = len(repo.branches) > 0
-
-    has_issues = (
-        untracked_count > 0
-        or stash_count > 0
-        or bool(unpushed_branches)
-        or bool(local_only_branches)
-        or any("merged" not in hint for _, hint in deleted_branches)
-        or bool(changes)
-    )
 
     # Build changes_summary
     changes_summary: List[str] = []
@@ -655,12 +617,11 @@ def get_repo_status(
                 f"Unhandled change type '{item.change_type}': {item.a_path}"
             )
 
-    return RepoStatus(
+    status = RepoStatus(
         rel_path=rel_path,
         branch=branch_name,
         mainline=mainline,
         is_git=True,
-        has_changes=has_issues,
         untracked_count=untracked_count,
         untracked_files=untracked,
         stash_count=stash_count,
@@ -670,6 +631,15 @@ def get_repo_status(
         local_only_branches=local_only_branches,
         deleted_upstream_branches=deleted_branches,
     )
+    status.has_changes = (
+        untracked_count > 0
+        or stash_count > 0
+        or bool(unpushed_branches)
+        or bool(local_only_branches)
+        or status.has_unmerged_deleted_branches
+        or bool(changes)
+    )
+    return status
 
 
 def print_repo_status(

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -51,7 +51,8 @@ def _repo_has_changes(repo_root: str, workspace_root: str) -> bool:
         repo = git.Repo(repo_root, search_parent_directories=False)
     except git.exc.InvalidGitRepositoryError:
         print_warn(f"{os.path.relpath(repo_root, workspace_root)} is not a git repo.")
-        return True
+        # Not a git repo, assume no changes - no local git history to check
+        return False
 
     try:
         stash_list = repo.git.stash("list")
@@ -226,13 +227,6 @@ def remove_packages(workspace_root: str, items: list[str]) -> int:
                 del repo_map[repo_root]
 
     for repo_root, repo_packages in repo_map.items():
-        repo_root_real = os.path.realpath(repo_root)
-        if not repo_root_real.startswith(src_root + os.path.sep):
-            print_error(
-                f"Refusing to remove non-src repository: {os.path.relpath(repo_root, workspace_root)}"
-            )
-            continue
-
         repo_rel = os.path.relpath(repo_root, workspace_root)
         print_info(f"About to clean {repo_rel}.")
         print("Includes the following packages:")

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -1,7 +1,7 @@
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Dict, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from .build import clean_packages
 from .print import Colors, confirm, print_error, print_info, print_warn, print_color
@@ -22,77 +22,88 @@ class RepoStatus:
     rel_path: str
     branch: str
     is_git: bool = False
+
+    # local changes / risks
     has_changes: bool = False
     untracked_count: int = 0
     stash_count: int = 0
+    changes_summary: List[str] = field(default_factory=list)
 
-    # Detailed lists for display
+    # only meaningful if fetch_remotes=True
     unpushed_branches: List[str] = field(default_factory=list)
     local_only_branches: List[str] = field(default_factory=list)
     deleted_upstream_branches: List[str] = field(default_factory=list)
-    changes_summary: List[str] = field(default_factory=list)
 
-    # For safety checks
     is_clean: bool = True
 
 
 def _get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
     """
-    Find the git root for a path, but stop searching if we hit the workspace src root.
-    This prevents detecting a git repo in the user's home directory by mistake.
-    """
-    current = path.resolve()
-    workspace_src = workspace_src.resolve()
+    Return the git working tree root for `path`, but ONLY if the repo root is
+    inside `workspace_src` (or equals it). Otherwise return None.
 
-    # Safety check: ensure we are actually inside the workspace src
+    This prevents accidentally picking up e.g. /home/user as a repo root.
+    """
+    workspace_src = workspace_src.resolve()
+    current = path.resolve()
+
+    # must be within ws/src
     if not current.is_relative_to(workspace_src):
         return None
 
     try:
-        # Ask git where the root is directly (fastest method)
-        # We use strict boundaries to ensure we don't jump out of the workspace
-        repo = git.Repo(current, search_parent_directories=True)
+        repo = Repo(current, search_parent_directories=True)
         repo_root = Path(repo.working_tree_dir).resolve()
-
-        # If the found repo root is OUTSIDE our workspace src, ignore it.
-        # This handles the case where user has a .git in /home/user/
-        if repo_root != workspace_src and not workspace_src.is_relative_to(repo_root):
-            # The workspace is inside the repo (nested), or repo is completely outside
-            if repo_root.is_relative_to(workspace_src) or repo_root == workspace_src:
-                return repo_root
-            # If the repo root is higher up than src, we treat this package as not-git-managed
-            return None
-
-        return repo_root
     except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
         return None
 
+    # accept only if repo root is within ws/src (or equals)
+    if repo_root == workspace_src or repo_root.is_relative_to(workspace_src):
+        return repo_root
 
-def _analyze_changes(repo: Repo) -> (List[str], int):
+    return None
+
+
+def _collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
     """
-    Summarize file changes (staged and unstaged).
-    Returns a list of strings describing changes and total count.
+    Return (changes_summary, modified_count, untracked_count) using
+    `git status --porcelain` (robust, fast, works even if HEAD is unborn).
     """
-    summary = []
-    total_modifications = 0
+    try:
+        out = repo.git.status("--porcelain=v1").splitlines()
+    except git.exc.GitCommandError:
+        out = []
 
-    # Check index (staged) and working tree (unstaged)
-    # R=True finds renames
-    for diff_list in [repo.index.diff("HEAD"), repo.index.diff(None)]:
-        for diff in diff_list:
-            total_modifications += 1
-            if diff.change_type == "M":
-                summary.append(f"Modified: {diff.a_path}")
-            elif diff.change_type == "A":
-                summary.append(f"Added: {diff.a_path}")
-            elif diff.change_type == "D":
-                summary.append(f"Deleted: {diff.a_path}")
-            elif diff.change_type == "R":
-                summary.append(f"Renamed: {diff.a_path} -> {diff.b_path}")
-            else:
-                summary.append(f"{diff.change_type}: {diff.a_path}")
+    changes_summary: List[str] = []
+    modified_count = 0
+    untracked_count = 0
 
-    return summary, total_modifications
+    for line in out:
+        if not line:
+            continue
+
+        # Untracked: "?? path"
+        if line.startswith("?? "):
+            untracked_count += 1
+            continue
+
+        # Format: XY <path> (or rename "R  old -> new")
+        xy = line[:2]
+        rest = line[3:] if len(line) > 3 else ""
+
+        modified_count += 1
+
+        # very simple labels (keep it readable)
+        if "R" in xy and "->" in rest:
+            changes_summary.append(f"Renamed: {rest}")
+        elif "D" in xy:
+            changes_summary.append(f"Deleted: {rest}")
+        elif "A" in xy:
+            changes_summary.append(f"Added: {rest}")
+        else:
+            changes_summary.append(f"Modified: {rest}")
+
+    return changes_summary, modified_count, untracked_count
 
 
 def _collect_repo_status(
@@ -105,67 +116,74 @@ def _collect_repo_status(
     except git.exc.InvalidGitRepositoryError:
         return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
 
-    # 1. Basic Info
+    # Branch info
     try:
         if repo.head.is_detached:
             branch_name = f"detached ({repo.head.commit.hexsha[:7]})"
         else:
             branch_name = repo.active_branch.name
-    except ValueError:
-        branch_name = "empty/unknown"
+    except Exception:
+        branch_name = "unknown"
 
-    # 2. Fetch if requested
-    if fetch:
-        for remote in repo.remotes:
-            try:
-                remote.fetch()
-            except git.exc.GitCommandError as e:
-                print_warn(f"Fetch failed for {remote.name} in {rel_path}: {e}")
+    # local working tree status
+    changes_summary, mod_count, untracked_count = _collect_worktree_changes(repo)
 
-    # 3. Analyze Branches
-    unpushed = []
-    local_only = []
-    deleted_upstream = []
-
-    for branch in repo.branches:
-        tracking = branch.tracking_branch()
-        if not tracking:
-            local_only.append(branch.name)
-            continue
-
-        if not tracking.is_valid():
-            deleted_upstream.append(branch.name)
-            continue
-
-        # Check for unpushed commits using rev-list (much faster than iter_commits)
-        try:
-            # count commits that are reachable from branch but not from tracking
-            commits_ahead = repo.git.rev_list(
-                "--count", f"{tracking.name}..{branch.name}"
-            )
-            if int(commits_ahead) > 0:
-                unpushed.append(branch.name)
-        except git.exc.GitCommandError:
-            pass
-
-    # 4. Changes and Stashes
+    # stashes
+    stash_count = 0
     try:
-        stash_count = (
-            len(repo.git.stash("list").splitlines()) if repo.git.stash("list") else 0
-        )
+        stash_out = repo.git.stash("list")
+        stash_count = len(stash_out.splitlines()) if stash_out else 0
     except git.exc.GitCommandError:
         stash_count = 0
 
-    untracked_files = repo.untracked_files
-    changes_summary, mod_count = _analyze_changes(repo)
+    # remote-related checks only if fetch=True (avoid lying when refs are stale)
+    unpushed: List[str] = []
+    local_only: List[str] = []
+    deleted_upstream: List[str] = []
+
+    if fetch:
+        for remote in repo.remotes:
+            try:
+                remote.fetch(prune=True)
+            except git.exc.GitCommandError as e:
+                print_warn(f"Fetch failed for {remote.name} in {rel_path}: {e}")
+
+        for branch in repo.branches:
+            tracking = branch.tracking_branch()
+            if not tracking:
+                local_only.append(branch.name)
+                continue
+
+            # tracking ref might still not exist locally; treat as deleted/unknown
+            try:
+                # "git show-ref --verify refs/remotes/..."
+                repo.git.show_ref(
+                    "--verify",
+                    f"refs/remotes/{tracking.remote_head}",
+                    with_exceptions=True,
+                )
+            except Exception:
+                # safer: just label as deleted/unknown if tracking cannot be verified after fetch
+                deleted_upstream.append(branch.name)
+                continue
+
+            try:
+                commits_ahead = int(
+                    repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
+                )
+                if commits_ahead > 0:
+                    unpushed.append(branch.name)
+            except Exception:
+                # ignore; keep script simple
+                pass
 
     has_changes = (
-        bool(untracked_files)
-        or bool(stash_count)
+        (mod_count > 0)
+        or (untracked_count > 0)
+        or (stash_count > 0)
         or bool(unpushed)
         or bool(local_only)
         or bool(deleted_upstream)
-        or mod_count > 0
     )
 
     return RepoStatus(
@@ -173,7 +191,7 @@ def _collect_repo_status(
         branch=branch_name,
         is_git=True,
         has_changes=has_changes,
-        untracked_count=len(untracked_files),
+        untracked_count=untracked_count,
         stash_count=stash_count,
         unpushed_branches=unpushed,
         local_only_branches=local_only,
@@ -183,42 +201,65 @@ def _collect_repo_status(
     )
 
 
-def _print_status_report(status: RepoStatus, packages: List[str]):
+def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool):
     print_info(f"Repo: {status.rel_path} ({status.branch})")
 
     if not status.is_git:
         print_warn("  [!] Not a git repository")
         return
 
-    labels = []
+    labels: List[str] = []
     if status.is_clean:
         labels.append("Clean")
     else:
-        if status.unpushed_branches:
-            labels.append("Unpushed commits")
-        if status.local_only_branches:
-            labels.append("Local-only branches")
-        if status.deleted_upstream_branches:
-            labels.append("Deleted upstream")
-        if status.stash_count:
-            labels.append("Stashed changes")
         if status.changes_summary or status.untracked_count:
             labels.append("Working tree dirty")
+        if status.stash_count:
+            labels.append("Stashed changes")
+        if fetched:
+            if status.unpushed_branches:
+                labels.append("Unpushed commits")
+            if status.local_only_branches:
+                labels.append("Local-only branches")
+            if status.deleted_upstream_branches:
+                labels.append("Upstream missing")
+        else:
+            if (
+                status.unpushed_branches
+                or status.local_only_branches
+                or status.deleted_upstream_branches
+            ):
+                # shouldn't happen, but keep logic consistent
+                labels.append("Remote status unknown")
 
     print_info(f"Status: {', '.join(labels)}")
 
-    # Details
     if status.has_changes:
-        for b in status.unpushed_branches:
-            print_color(Colors.RED, f"  Unpushed: {b}")
-        for b in status.local_only_branches:
-            print_color(Colors.LRED, f"  No Upstream: {b}")
-        for b in status.deleted_upstream_branches:
-            print_color(Colors.YELLOW, f"  Upstream Deleted: {b}")
-        for change in status.changes_summary:
+        if fetched:
+            for b in status.unpushed_branches:
+                print_color(Colors.RED, f"  Unpushed: {b}")
+            for b in status.local_only_branches:
+                print_color(Colors.LRED, f"  No Upstream: {b}")
+            for b in status.deleted_upstream_branches:
+                print_color(Colors.YELLOW, f"  Upstream Missing: {b}")
+        else:
+            # gentle hint
+            print_color(
+                Colors.LGRAY,
+                "  (Hint: run with fetch_remotes=True to check upstream state)",
+            )
+
+        for change in status.changes_summary[:50]:
             print_color(Colors.ORANGE, f"  {change}")
+        if len(status.changes_summary) > 50:
+            print_color(
+                Colors.LGRAY, f"  ... +{len(status.changes_summary) - 50} more changes"
+            )
+
         if status.untracked_count:
             print_color(Colors.LGRAY, f"  {status.untracked_count} untracked files")
+        if status.stash_count:
+            print_color(Colors.LGRAY, f"  {status.stash_count} stash entries")
 
     print("Packages in this repo:")
     for p in sorted(packages):
@@ -233,80 +274,69 @@ def remove_packages(
         return 1
 
     workspace_root = Path(workspace_root_str).resolve()
-    src_root = workspace_root / "src"
+    src_root = (workspace_root / "src").resolve()
 
     if not items:
         print_error("No packages specified.")
         return 1
 
-    # Deduplicate items
-    items = list(dict.fromkeys(items))
+    items = list(dict.fromkeys(items))  # deduplicate while preserving order
 
     repo_map: Dict[Path, List[str]] = {}
     repos_explicitly_selected: Set[Path] = set()
-    missing_items = []
+    missing_items: List[str] = []
 
-    # 1. Resolve Items to Repositories
+    # 1) Resolve items to repos
     for item in items:
-        # Check if item is a package name
         pkg_path_str = get_package_path(item, str(workspace_root))
 
         if pkg_path_str:
             repo_root = _get_repo_root(Path(pkg_path_str), src_root)
             if not repo_root:
-                print_error(
-                    f"Package '{item}' is not in a recognized git repo within src."
-                )
+                print_error(f"Package '{item}' is not in a git repo within {src_root}.")
                 return 1
-
-            if repo_root not in repo_map:
-                repo_map[repo_root] = []
+            repo_map.setdefault(repo_root, [])
             if item not in repo_map[repo_root]:
                 repo_map[repo_root].append(item)
+            continue
 
-        else:
-            # Check if item is a directory path (relative to ws or src)
-            candidate = workspace_root / item
-            candidate_src = src_root / item
+        # treat as path (relative to ws or src)
+        candidate_ws = workspace_root / item
+        candidate_src = src_root / item
 
-            found_repo = None
-            if candidate.is_dir():
-                found_repo = candidate.resolve()
-            elif candidate_src.is_dir():
-                found_repo = candidate_src.resolve()
+        found_path: Optional[Path] = None
+        if candidate_ws.is_dir():
+            found_path = candidate_ws
+        elif candidate_src.is_dir():
+            found_path = candidate_src
 
-            if found_repo:
-                # Verify it's actually a repo or inside one
-                real_repo = _get_repo_root(found_repo, src_root)
-                if real_repo:
-                    repos_explicitly_selected.add(real_repo)
-                    # We will populate packages later
-                    if real_repo not in repo_map:
-                        repo_map[real_repo] = []
-                else:
-                    print_error(f"Path '{item}' is not a git repository.")
-            else:
-                missing_items.append(item)
+        if not found_path:
+            missing_items.append(item)
+            continue
+
+        real_repo = _get_repo_root(found_path, src_root)
+        if not real_repo:
+            print_error(f"Path '{item}' is not a git repository inside {src_root}.")
+            return 1
+
+        repos_explicitly_selected.add(real_repo)
+        repo_map.setdefault(real_repo, [])
 
     if missing_items:
         print_error(f"Not found: {', '.join(missing_items)}")
         return 1
 
-    # 2. Check for "Partial" Repo Removals
-    # If user asked to remove pkg A, but Repo contains A and B, we must ask.
-    final_repos_to_process = []
+    # 2) Determine final repos and packages to clean
+    final_repos_to_process: List[Tuple[Path, List[str]]] = []
 
     for repo_root, requested_pkgs in repo_map.items():
         all_pkgs_in_repo = find_packages_in_directory(str(repo_root))
 
-        # If the user selected the REPO path explicitly, they imply deleting everything.
         if repo_root in repos_explicitly_selected:
             final_repos_to_process.append((repo_root, all_pkgs_in_repo))
             continue
 
-        # Otherwise, check if they missed any packages
         extra_pkgs = [p for p in all_pkgs_in_repo if p not in requested_pkgs]
-
         if extra_pkgs:
             repo_rel = repo_root.relative_to(workspace_root)
             print_warn(
@@ -318,32 +348,37 @@ def remove_packages(
 
         final_repos_to_process.append((repo_root, all_pkgs_in_repo))
 
-    # 3. Execution Phase
+    # 3) Execute deletions
     for repo_root, packages in final_repos_to_process:
+        repo_root = repo_root.resolve()
         repo_rel = repo_root.relative_to(workspace_root)
 
-        # Safety: Final check that we are deleting something inside src
+        # final safety guard
         if not repo_root.is_relative_to(src_root):
-            print_error(f"SAFETY GUARD: Refusing to delete {repo_root} (outside src)")
+            print_error(
+                f"SAFETY GUARD: Refusing to delete {repo_root} (outside {src_root})"
+            )
             continue
 
         status = _collect_repo_status(repo_root, workspace_root, fetch_remotes)
-        _print_status_report(status, packages)
+        _print_status_report(status, packages, fetched=fetch_remotes)
 
+        # Decide whether to warn
         has_uncommitted = bool(status.changes_summary) or status.untracked_count > 0
+        has_local_work = has_uncommitted or (status.stash_count > 0)
         has_unpushed = bool(status.unpushed_branches) or bool(
             status.local_only_branches
         )
-        if has_uncommitted or has_unpushed:
-            print_error(
-                "WARNING: repository has uncommitted changes or unpushed commits."
-            )
+
+        if has_local_work or has_unpushed:
+            print_error("WARNING: local work will be lost (dirty/stash/unpushed).")
             if not confirm(f"Proceed with deletion of {repo_rel} anyway?"):
                 continue
+
         if not confirm(f"DELETE {repo_rel}?"):
             continue
 
-        # Clean build artifacts first -> install and build folders
+        # clean build artifacts first
         if packages:
             if not clean_packages(str(workspace_root), packages, force=True):
                 print_error("Failed to clean build artifacts.")

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -1,0 +1,253 @@
+import os
+import shutil
+
+from .build import clean_packages
+from .print import Colors, confirm, print_error, print_info, print_warn, print_color
+from .workspace import find_packages_in_directory, get_package_path
+
+try:
+    import git
+except ImportError:
+    print_error(
+        "GitPython is required! Install using 'pip3 install --user gitpython' or 'apt install python3-git'"
+    )
+    raise
+
+
+def _repo_root_from_package_path(package_path: str, workspace_root: str) -> str | None:
+    try:
+        repo = git.Repo(package_path, search_parent_directories=True)
+        return repo.working_tree_dir
+    except git.exc.InvalidGitRepositoryError:
+        src_root = os.path.realpath(os.path.join(workspace_root, "src"))
+        path = os.path.realpath(package_path)
+        while path and path != src_root:
+            parent = os.path.realpath(os.path.dirname(path))
+            if parent == src_root:
+                return path
+            if parent == path:
+                break
+            path = parent
+    return None
+
+
+def _repo_root_from_input(target: str, workspace_root: str) -> str | None:
+    if os.path.isdir(target):
+        return os.path.realpath(target)
+    if os.path.isabs(target):
+        return None
+    candidates = [
+        os.path.join(workspace_root, "src", target),
+        os.path.join(workspace_root, target),
+    ]
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return os.path.realpath(candidate)
+    return None
+
+
+def _repo_has_changes(repo_root: str, workspace_root: str) -> bool:
+    try:
+        repo = git.Repo(repo_root, search_parent_directories=False)
+    except git.exc.InvalidGitRepositoryError:
+        print_warn(f"{os.path.relpath(repo_root, workspace_root)} is not a git repo.")
+        return True
+
+    try:
+        stash_list = repo.git.stash("list")
+        changes = list(repo.index.diff(None))
+    except git.exc.GitCommandError as e:
+        print_error(
+            f"Failed to obtain changes for {os.path.relpath(repo_root, workspace_root)}: {e}"
+        )
+        return True
+
+    try:
+        changes += list(repo.index.diff("HEAD", R=True))
+    except git.BadName:
+        pass
+
+    untracked = repo.untracked_files
+    unpushed_branches = []
+    local_branches = []
+    deleted_branches = []
+    for branch in repo.branches:
+        tracking = branch.tracking_branch()
+        if tracking is None:
+            local_branches.append(branch)
+            continue
+        if not tracking.is_valid():
+            deleted_branches.append(branch)
+            continue
+        try:
+            if any(
+                True for _ in repo.iter_commits(f"{branch.name}@{{u}}..{branch.name}")
+            ):
+                unpushed_branches.append(branch)
+        except git.exc.GitCommandError as e:
+            print_error(
+                f"{os.path.relpath(repo_root, workspace_root)} has error on branch {branch.name}: {e}"
+            )
+            return True
+
+    has_changes = (
+        any(untracked)
+        or bool(stash_list)
+        or any(unpushed_branches)
+        or any(local_branches)
+        or any(deleted_branches)
+        or any(changes)
+    )
+
+    if not has_changes:
+        return False
+
+    if not repo.head.is_valid():
+        branch_name = "unknown"
+    elif repo.head.is_detached:
+        branch_name = f"detached at {repo.head.commit}"
+    else:
+        branch_name = repo.head.ref.name
+
+    print_info(
+        f"{os.path.relpath(repo_root, workspace_root)} {Colors.LPURPLE}({branch_name})"
+    )
+    for branch in unpushed_branches:
+        print_color(Colors.RED, f"  Unpushed commits on branch {branch}!")
+    for branch in local_branches:
+        print_color(Colors.LRED, f"  Local branch with no upstream: {branch}")
+    for branch in deleted_branches:
+        print_color(Colors.LRED, f"  Local branch with deleted upstream: {branch}")
+    if bool(stash_list):
+        print_color(Colors.LCYAN, "  Stashed changes")
+    for item in changes:
+        if item.change_type.startswith("M"):
+            print_color(Colors.ORANGE, f"  Modified: {item.a_path}")
+        elif item.change_type.startswith("D"):
+            print_color(Colors.RED, f"  Deleted: {item.a_path}")
+        elif item.change_type.startswith("R"):
+            print_color(Colors.GREEN, f"  Renamed: {item.a_path} -> {item.b_path}")
+        elif item.change_type.startswith("A"):
+            print_color(Colors.GREEN, f"  Added: {item.a_path}")
+        elif item.change_type.startswith("U"):
+            print_error(f"  Unmerged: {item.a_path}")
+        elif item.change_type.startswith("C"):
+            print_color(Colors.GREEN, f"  Copied: {item.a_path} -> {item.b_path}")
+        elif item.change_type.startswith("T"):
+            print_color(Colors.ORANGE, f"  Type changed: {item.a_path}")
+        else:
+            print_color(
+                Colors.RED,
+                f"  Unhandled change type '{item.change_type}': {item.a_path}",
+            )
+    if len(untracked) < 10:
+        for file in untracked:
+            print_color(Colors.LGRAY, f"  Untracked: {file}")
+    else:
+        print_color(Colors.LGRAY, f"  {len(untracked)} untracked files.")
+    print("")
+    return True
+
+
+def remove_packages(workspace_root: str, packages: list[str]) -> int:
+    if workspace_root is None:
+        print_error("No workspace configured!")
+        return 1
+
+    if not packages:
+        print_error("No packages specified for removal.")
+        return 1
+
+    packages_unique = []
+    seen = set()
+    for package in packages:
+        if package not in seen:
+            packages_unique.append(package)
+            seen.add(package)
+
+    repo_map: dict[str, list[str]] = {}
+    selected_repo_roots: set[str] = set()
+    missing_targets = []
+    for package in packages_unique:
+        package_path = get_package_path(package, workspace_root)
+        if package_path is not None:
+            repo_root = _repo_root_from_package_path(package_path, workspace_root)
+            if repo_root is None:
+                print_error(f"Failed to locate repository for {package}.")
+                return 1
+            repo_root = os.path.realpath(repo_root)
+            if repo_root not in selected_repo_roots:
+                repo_packages = repo_map.setdefault(repo_root, [])
+                if package not in repo_packages:
+                    repo_packages.append(package)
+            continue
+
+        repo_root = _repo_root_from_input(package, workspace_root)
+        if repo_root is not None:
+            repo_root = os.path.realpath(repo_root)
+            selected_repo_roots.add(repo_root)
+            repo_map[repo_root] = find_packages_in_directory(repo_root)
+            continue
+
+        missing_targets.append(package)
+
+    if missing_targets:
+        print_error(f"Packages or repositories not found: {', '.join(missing_targets)}")
+        return 1
+
+    src_root = os.path.realpath(os.path.join(workspace_root, "src"))
+    for repo_root in list(repo_map.keys()):
+        if repo_root not in selected_repo_roots:
+            repo_packages = find_packages_in_directory(repo_root)
+            extra_packages = [p for p in repo_packages if p not in packages_unique]
+            if extra_packages:
+                repo_rel = os.path.relpath(repo_root, workspace_root)
+                if not confirm(
+                    f"Repository '{repo_rel}' contains additional packages "
+                    f"not requested for removal: {', '.join(extra_packages)}. "
+                    "Remove entire repository anyway?"
+                ):
+                    print_info(f"Skipping repository {repo_rel}.")
+                    del repo_map[repo_root]
+                    continue
+            repo_map[repo_root] = repo_packages
+        else:
+            repo_map[repo_root] = find_packages_in_directory(repo_root)
+
+    for repo_root in list(repo_map.keys()):
+        if _repo_has_changes(repo_root, workspace_root):
+            if not confirm(
+                "Repository has local changes, stashes, or unpushed commits. "
+                "Remove anyway (brute-force)?"
+            ):
+                print_info(
+                    f"Skipping repository {os.path.relpath(repo_root, workspace_root)}."
+                )
+                del repo_map[repo_root]
+
+    for repo_root, repo_packages in repo_map.items():
+        repo_root_real = os.path.realpath(repo_root)
+        if not repo_root_real.startswith(src_root + os.path.sep):
+            print_error(
+                f"Refusing to remove non-src repository: {os.path.relpath(repo_root, workspace_root)}"
+            )
+            continue
+
+        repo_rel = os.path.relpath(repo_root, workspace_root)
+        if not confirm(f"Are you sure you want to clean {repo_rel}?"):
+            print_info(f"Skipping repository {repo_rel}.")
+            continue
+
+        if not repo_packages:
+            print_warn(f"No packages found in {repo_rel}. Skipping cleanup.")
+            continue
+
+        if not clean_packages(workspace_root, repo_packages, force=True):
+            print_error(f"Failed to clean build/install for {repo_rel}.")
+            continue
+
+        print_info(f"Removing source at {repo_rel}...")
+        shutil.rmtree(repo_root)
+        print_info(f"Removed {repo_rel}.")
+
+    return 0

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -1,4 +1,6 @@
 import shutil
+import subprocess
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
@@ -21,6 +23,7 @@ class RepoStatus:
 
     rel_path: str
     branch: str
+    mainline: str = "unknown"
     is_git: bool = False
 
     # local changes / risks
@@ -51,17 +54,13 @@ def _get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
     # must be within ws/src
     if not current.is_relative_to(workspace_src):
         return None
-
     try:
         repo = Repo(current, search_parent_directories=True)
         repo_root = Path(repo.working_tree_dir).resolve()
     except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
         return None
-
-    # accept only if repo root is within ws/src (or equals)
     if repo_root == workspace_src or repo_root.is_relative_to(workspace_src):
         return repo_root
-
     return None
 
 
@@ -74,28 +73,16 @@ def _collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
         out = repo.git.status("--porcelain=v1").splitlines()
     except git.exc.GitCommandError:
         out = []
-
-    changes_summary: List[str] = []
-    modified_count = 0
-    untracked_count = 0
-
+    changes_summary, modified_count, untracked_count = [], 0, 0
     for line in out:
         if not line:
             continue
-
-        # Untracked: "?? path"
         if line.startswith("?? "):
             untracked_count += 1
             continue
-
-        # Format: XY <path> (or rename "R  old -> new")
-        xy = line[:2]
-        rest = line[3:] if len(line) > 3 else ""
-
+        xy, rest = line[:2], line[3:]
         modified_count += 1
-
-        # very simple labels (keep it readable)
-        if "R" in xy and "->" in rest:
+        if "R" in xy:
             changes_summary.append(f"Renamed: {rest}")
         elif "D" in xy:
             changes_summary.append(f"Deleted: {rest}")
@@ -103,7 +90,6 @@ def _collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
             changes_summary.append(f"Added: {rest}")
         else:
             changes_summary.append(f"Modified: {rest}")
-
     return changes_summary, modified_count, untracked_count
 
 
@@ -113,15 +99,29 @@ def _remote_head_mainline_ref(repo: git.Repo, remote_name: str) -> str | None:
     Returns a ref like '<remote>/<branch>' (e.g. 'origin/ros2') or None.
     """
     head_ref = f"refs/remotes/{remote_name}/HEAD"
-    try:
-        sym = repo.git.symbolic_ref("-q", head_ref).strip()
-        if not sym:
-            return None
-        prefix = f"refs/remotes/{remote_name}/"
-        if sym.startswith(prefix):
-            return f"{remote_name}/{sym[len(prefix):]}"
+    prefix = f"refs/remotes/{remote_name}/"
+
+    def try_resolve():
+        try:
+            sym = repo.git.symbolic_ref("-q", head_ref).strip()
+            if sym and sym.startswith(prefix):
+                return f"{remote_name}/{sym[len(prefix):]}"
+        except git.exc.GitCommandError:
+            pass
         return None
-    except git.exc.GitCommandError:
+
+    resolved = try_resolve()
+    if resolved:
+        return resolved
+    try:
+        subprocess.run(
+            ["git", "remote", "set-head", remote_name, "-a"],
+            cwd=repo.working_tree_dir,
+            capture_output=True,
+            timeout=10,
+        )
+        return try_resolve()
+    except Exception:
         return None
 
 
@@ -134,40 +134,28 @@ def _get_dynamic_mainline(repo: git.Repo) -> str:
         mainline_ref = _remote_head_mainline_ref(repo, remote.name)
         if mainline_ref:
             return mainline_ref.split("/", 1)[1]
-
-    for candidate in ["main", "master", "develop"]:
-        if candidate in repo.heads:
+    ros_distro = os.environ.get("ROS_DISTRO", "").lower()
+    for candidate in [ros_distro, "main", "master"]:
+        if candidate and candidate in repo.heads:
             return candidate
     return "main"
 
 
-def _find_merge_evidence(repo: git.Repo, branch: git.Head, mainline: str) -> str:
-    """
-    Determines if a branch was merged into the remote mainline or abandoned.
-    Tests for direct ancestry and squashed commit messages against the remote ref.
-    """
+def _find_merge_evidence(
+    repo: git.Repo, branch: git.Head, mainline: str
+) -> Tuple[bool, str]:
     try:
-        # 1. Resolve the tracking branch for mainline (e.g., 'main' -> 'origin/main')
         local_mainline = repo.heads[mainline]
         tracking_ref = local_mainline.tracking_branch()
-        print(
-            f"Debug: Checking merge evidence for branch {branch.name} against mainline {mainline} (tracking: {tracking_ref})"
-        )
-
-        # If no tracking branch exists, fall back to local mainline for the check
-        # 'target' will be a string like 'origin/main' or 'main'
         target = tracking_ref.name if tracking_ref else mainline
 
-        # 2. Direct Ancestry (Standard Merge or Rebase)
-        # Check if the branch commit is an ancestor of the remote mainline tip
+        # 1. Direct Ancestry
         if repo.is_ancestor(branch.commit, target):
-            return f"merged into {target}"
+            return True, f"merged into {target}"
 
-        # 3. Squash Merge Search
-        # Limits search to remote mainline commits after the branch's last activity
+        # 2. Squash Merge Search
         since_date = branch.commit.committed_datetime.isoformat()
-
-        found_commit = repo.git.log(
+        found = repo.git.log(
             target,
             f"--grep={branch.name}",
             f"--since={since_date}",
@@ -175,35 +163,31 @@ def _find_merge_evidence(repo: git.Repo, branch: git.Head, mainline: str) -> str
             "-n",
             "1",
         )
+        if found:
+            return True, f"merged into {target} (squashed)"
 
-        if found_commit:
-            return f"merged into {target} (squashed)"
-
-    except Exception as e:
-        # Useful for debugging why a specific check failed
-        # print(f"Debug: Evidence check failed for {branch.name}: {e}")
+        return False, f"merge into {target} unverified"
+    except Exception:
         pass
-
-    return "probably abandoned"
+    return False, f"merge into {mainline} unverified"
 
 
 def _collect_repo_status(
     repo_path: Path, workspace_root: Path, fetch: bool
 ) -> RepoStatus:
     rel_path = str(repo_path.relative_to(workspace_root))
-
     try:
         repo = Repo(repo_path)
     except git.exc.InvalidGitRepositoryError:
         return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
 
     mainline = _get_dynamic_mainline(repo)
-
     try:
-        if repo.head.is_detached:
-            branch_name = f"detached ({repo.head.commit.hexsha[:7]})"
-        else:
-            branch_name = repo.active_branch.name
+        branch_name = (
+            f"detached ({repo.head.commit.hexsha[:7]})"
+            if repo.head.is_detached
+            else repo.active_branch.name
+        )
     except Exception:
         branch_name = "unknown"
 
@@ -216,19 +200,20 @@ def _collect_repo_status(
         stash_out = repo.git.stash("list")
         stash_count = len(stash_out.splitlines()) if stash_out else 0
     except git.exc.GitCommandError:
-        stash_count = 0
+        pass
 
-    # remote-related checks only if fetch=True (avoid lying when refs are stale)
-    unpushed: List[str] = []
-    local_only: List[str] = []
-    deleted_upstream: List[Tuple[str, str]] = []
-
+    unpushed, local_only, deleted_upstream = [], [], []
     if fetch:
-        for remote in repo.remotes:
-            try:
-                remote.fetch(prune=True)
-            except git.exc.GitCommandError as e:
-                print_warn(f"Fetch failed for {remote.name} in {rel_path}: {e}")
+        try:
+            # use subprocess for speed and timeout
+            subprocess.run(
+                ["git", "fetch", "--prune", "--all", "--quiet"],
+                cwd=str(repo_path),
+                capture_output=True,
+                timeout=30,
+            )
+        except Exception as e:
+            print_warn(f"Fetch failed for {rel_path}: {e}")
 
         for branch in repo.branches:
             tracking = branch.tracking_branch()
@@ -241,24 +226,22 @@ def _collect_repo_status(
                 # Use tracking.path (refs/remotes/...) to verify physical existence
                 repo.git.show_ref("--verify", tracking.path, with_exceptions=True)
             except Exception:
-                # Upstream is gone: try to find out if it was merged
-                hint = _find_merge_evidence(repo, branch, mainline)
+                _, hint = _find_merge_evidence(repo, branch, mainline)
                 deleted_upstream.append((branch.name, hint))
                 continue
-
             try:
-                commits_ahead = int(
-                    repo.git.rev_list("--count", f"{tracking.name}..{branch.name}")
-                )
-                if commits_ahead > 0:
+                if (
+                    int(repo.git.rev_list("--count", f"{tracking.name}..{branch.name}"))
+                    > 0
+                ):
                     unpushed.append(branch.name)
             except Exception:
                 pass
 
     has_changes = (
-        (mod_count > 0)
-        or (untracked_count > 0)
-        or (stash_count > 0)
+        mod_count > 0
+        or untracked_count > 0
+        or stash_count > 0
         or bool(unpushed)
         or bool(local_only)
         or bool(deleted_upstream)
@@ -267,6 +250,7 @@ def _collect_repo_status(
     return RepoStatus(
         rel_path=rel_path,
         branch=branch_name,
+        mainline=mainline,
         is_git=True,
         has_changes=has_changes,
         untracked_count=untracked_count,
@@ -280,13 +264,14 @@ def _collect_repo_status(
 
 
 def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool):
-    print_info(f"Repo: {status.rel_path} ({status.branch})")
-
+    print_info(
+        f"Repo: {status.rel_path} (local: {status.branch} | mainline: {status.mainline})"
+    )
     if not status.is_git:
         print_warn("  [!] Not a git repository")
         return
 
-    labels: List[str] = []
+    labels = []
     if status.is_clean:
         labels.append("Clean")
     else:
@@ -303,7 +288,6 @@ def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool)
                 labels.append("Upstream missing")
 
     print_info(f"Status: {', '.join(labels)}")
-
     if status.has_changes:
         if fetched:
             for b in status.unpushed_branches:
@@ -318,14 +302,10 @@ def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool)
 
         for change in status.changes_summary[:50]:
             print_color(Colors.ORANGE, f"  {change}")
-        if len(status.changes_summary) > 50:
-            print_color(Colors.LGRAY, f"  ... +{len(status.changes_summary) - 50} more")
-
         if status.untracked_count:
             print_color(Colors.LGRAY, f"  {status.untracked_count} untracked files")
         if status.stash_count:
             print_color(Colors.LGRAY, f"  {status.stash_count} stash entries")
-
     print("Packages in this repo:")
     for p in sorted(packages):
         print(f"  - {p}")
@@ -337,18 +317,16 @@ def remove_packages(
     if not workspace_root_str:
         print_error("No workspace configured!")
         return 1
-
-    workspace_root = Path(workspace_root_str).resolve()
-    src_root = (workspace_root / "src").resolve()
-
+    workspace_root, src_root = (
+        Path(workspace_root_str).resolve(),
+        (Path(workspace_root_str) / "src").resolve(),
+    )
     if not items:
         print_error("No packages specified.")
         return 1
 
     items = list(dict.fromkeys(items))
-    repo_map: Dict[Path, List[str]] = {}
-    repos_explicitly_selected: Set[Path] = set()
-    missing_items: List[str] = []
+    repo_map, repos_explicitly_selected, missing_items = {}, set(), []
 
     # 1) Resolve items to repos
     for item in items:
@@ -358,27 +336,21 @@ def remove_packages(
             if not repo_root:
                 print_error(f"Package '{item}' is not in a git repo within {src_root}.")
                 return 1
-            repo_map.setdefault(repo_root, [])
-            if item not in repo_map[repo_root]:
-                repo_map[repo_root].append(item)
+            repo_map.setdefault(repo_root, []).append(item)
             continue
-
-        # treat as path (relative to ws or src)
-        candidate_ws = workspace_root / item
-        candidate_src = src_root / item
-        found_path = next(
-            (p for p in [candidate_ws, candidate_src] if p.is_dir()), None
+        candidate_ws, candidate_src = workspace_root / item, src_root / item
+        found_path = (
+            candidate_ws
+            if candidate_ws.is_dir()
+            else (candidate_src if candidate_src.is_dir() else None)
         )
-
         if not found_path:
             missing_items.append(item)
             continue
-
         real_repo = _get_repo_root(found_path, src_root)
         if not real_repo:
             print_error(f"Path '{item}' is not a git repository inside {src_root}.")
             return 1
-
         repos_explicitly_selected.add(real_repo)
         repo_map.setdefault(real_repo, [])
 
@@ -386,56 +358,38 @@ def remove_packages(
         print_error(f"Not found: {', '.join(missing_items)}")
         return 1
 
-    # 2) Determine final repos and packages to clean
-    final_repos_to_process: List[Tuple[Path, List[str]]] = []
-    for repo_root, requested_pkgs in repo_map.items():
-        all_pkgs_in_repo = find_packages_in_directory(str(repo_root))
-        if repo_root in repos_explicitly_selected:
-            final_repos_to_process.append((repo_root, all_pkgs_in_repo))
-            continue
-
-        extra_pkgs = [p for p in all_pkgs_in_repo if p not in requested_pkgs]
-        if extra_pkgs:
-            repo_rel = repo_root.relative_to(workspace_root)
-            print_warn(
-                f"Repo '{repo_rel}' contains other packages: {', '.join(extra_pkgs)}"
-            )
-            if not confirm("Remove the entire repository and all these packages?"):
-                continue
-        final_repos_to_process.append((repo_root, all_pkgs_in_repo))
+    final_repos = []
+    for repo_root, requested in repo_map.items():
+        all_pkgs = find_packages_in_directory(str(repo_root))
+        if repo_root not in repos_explicitly_selected:
+            extra = [p for p in all_pkgs if p not in requested]
+            if extra:
+                print_warn(
+                    f"Repo '{repo_root.relative_to(workspace_root)}' contains other packages: {', '.join(extra)}"
+                )
+                if not confirm("Remove the entire repository and all these packages?"):
+                    continue
+        final_repos.append((repo_root, all_pkgs))
 
     success = True
-    for repo_root, packages in final_repos_to_process:
-        repo_root = repo_root.resolve()
+    for repo_root, packages in final_repos:
         repo_rel = repo_root.relative_to(workspace_root)
-
-        if not repo_root.is_relative_to(src_root):
-            print_error(
-                f"SAFETY GUARD: Refusing to delete {repo_root} (outside {src_root})"
-            )
-            continue
-
         status = _collect_repo_status(repo_root, workspace_root, fetch_remotes)
         _print_status_report(status, packages, fetched=fetch_remotes)
 
-        # Logic: Don't consider a branch "lost work" if it's already merged
-        has_unpushed = bool(status.unpushed_branches) or bool(
-            status.local_only_branches
-        )
-
-        # Only warn for deleted upstreams that aren't merged
         unmerged_deleted = [
             b for b, hint in status.deleted_upstream_branches if "merged" not in hint
         ]
-
         has_local_work = (
             bool(status.changes_summary)
             or status.untracked_count > 0
             or status.stash_count > 0
             or bool(unmerged_deleted)
+            or bool(status.unpushed_branches)
+            or bool(status.local_only_branches)
         )
 
-        if has_local_work or has_unpushed:
+        if has_local_work:
             print_error(
                 "WARNING: local work will be lost (dirty/stash/unpushed/unmerged)."
             )
@@ -449,7 +403,7 @@ def remove_packages(
         if packages:
             if not clean_packages(str(workspace_root), packages, force=True):
                 print_error("Failed to clean build artifacts.")
-
+        # then delete the repo itself
         print_info(f"Deleting {repo_rel}...")
         try:
             shutil.rmtree(repo_root)
@@ -457,5 +411,4 @@ def remove_packages(
         except OSError as e:
             print_error(f"Failed to delete {repo_root}: {e}")
             success = False
-
     return 0 if success else 1

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -154,16 +154,14 @@ def _collect_repo_status(
                 local_only.append(branch.name)
                 continue
 
-            # tracking ref might still not exist locally; treat as deleted/unknown
+            # Verify the tracking reference actually exists in the local git store
             try:
-                # "git show-ref --verify refs/remotes/..."
-                repo.git.show_ref(
-                    "--verify",
-                    f"refs/remotes/{tracking.remote_head}",
-                    with_exceptions=True,
-                )
+                # tracking.path returns the full string like 'refs/remotes/origin/main'
+                print(tracking.path)
+                repo.git.show_ref("--verify", tracking.path, with_exceptions=True)
+                print(f"Verified tracking ref {tracking.path} for branch {branch.name}")
             except Exception:
-                # safer: just label as deleted/unknown if tracking cannot be verified after fetch
+                # If we fetched and the ref is gone, the upstream branch was likely deleted
                 deleted_upstream.append(branch.name)
                 continue
 
@@ -174,7 +172,6 @@ def _collect_repo_status(
                 if commits_ahead > 0:
                     unpushed.append(branch.name)
             except Exception:
-                # ignore; keep script simple
                 pass
 
     has_changes = (
@@ -349,6 +346,7 @@ def remove_packages(
         final_repos_to_process.append((repo_root, all_pkgs_in_repo))
 
     # 3) Execute deletions
+    sucess = True
     for repo_root, packages in final_repos_to_process:
         repo_root = repo_root.resolve()
         repo_rel = repo_root.relative_to(workspace_root)
@@ -389,5 +387,6 @@ def remove_packages(
             print_info("Deleted.")
         except OSError as e:
             print_error(f"Failed to delete {repo_root}: {e}")
+            sucess = False
 
-    return 0
+    return 0 if sucess else 1

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -95,7 +95,7 @@ def remove_packages(
                     timeout=30,
                 )
             except Exception:
-                pass
+                pass  # Fetch is optional; proceed with local state
 
         status = print_repo_status(repo_root, workspace_root, always_print_header=True)
 

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -1,266 +1,22 @@
 import shutil
-import subprocess
-import os
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import List
 
 from .build import clean_packages
+from .git_helpers import (
+    RepoStatus,
+    collect_repo_status,
+    get_repo_root,
+    find_merge_evidence,
+)
 from .print import Colors, confirm, print_error, print_info, print_warn, print_color
 from .workspace import find_packages_in_directory, get_package_path
 
 try:
     import git
-    from git import Repo
 except ImportError:
     print_error("GitPython is required! Install using 'pip install gitpython'")
     raise
-
-
-@dataclass
-class RepoStatus:
-    """Structured container for repository status."""
-
-    rel_path: str
-    branch: str
-    mainline: str = "unknown"
-    is_git: bool = False
-
-    # local changes / risks
-    has_changes: bool = False
-    untracked_count: int = 0
-    stash_count: int = 0
-    changes_summary: List[str] = field(default_factory=list)
-
-    # only meaningful if fetch_remotes=True
-    unpushed_branches: List[str] = field(default_factory=list)
-    local_only_branches: List[str] = field(default_factory=list)
-    # Stores tuples of (branch_name, merge_hint)
-    deleted_upstream_branches: List[Tuple[str, str]] = field(default_factory=list)
-
-    is_clean: bool = True
-
-
-def _get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
-    """
-    Return the git working tree root for `path`, but ONLY if the repo root is
-    inside `workspace_src` (or equals it). Otherwise return None.
-
-    This prevents accidentally picking up e.g. /home/user as a repo root.
-    """
-    workspace_src = workspace_src.resolve()
-    current = path.resolve()
-
-    # must be within ws/src
-    if not current.is_relative_to(workspace_src):
-        return None
-    try:
-        repo = Repo(current, search_parent_directories=True)
-        repo_root = Path(repo.working_tree_dir).resolve()
-    except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
-        return None
-    if repo_root == workspace_src or repo_root.is_relative_to(workspace_src):
-        return repo_root
-    return None
-
-
-def _collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
-    """
-    Return (changes_summary, modified_count, untracked_count) using
-    `git status --porcelain`.
-    """
-    try:
-        out = repo.git.status("--porcelain=v1").splitlines()
-    except git.exc.GitCommandError:
-        out = []
-    changes_summary, modified_count, untracked_count = [], 0, 0
-    for line in out:
-        if not line:
-            continue
-        if line.startswith("?? "):
-            untracked_count += 1
-            continue
-        xy, rest = line[:2], line[3:]
-        modified_count += 1
-        if "R" in xy:
-            changes_summary.append(f"Renamed: {rest}")
-        elif "D" in xy:
-            changes_summary.append(f"Deleted: {rest}")
-        elif "A" in xy:
-            changes_summary.append(f"Added: {rest}")
-        else:
-            changes_summary.append(f"Modified: {rest}")
-    return changes_summary, modified_count, untracked_count
-
-
-def _remote_head_mainline_ref(repo: git.Repo, remote_name: str) -> str | None:
-    """
-    Resolve the remote's configured mainline via refs/remotes/<remote>/HEAD.
-    Returns a ref like '<remote>/<branch>' (e.g. 'origin/ros2') or None.
-    """
-    head_ref = f"refs/remotes/{remote_name}/HEAD"
-    prefix = f"refs/remotes/{remote_name}/"
-
-    def try_resolve():
-        try:
-            sym = repo.git.symbolic_ref("-q", head_ref).strip()
-            if sym and sym.startswith(prefix):
-                return f"{remote_name}/{sym[len(prefix):]}"
-        except git.exc.GitCommandError:
-            pass
-        return None
-
-    resolved = try_resolve()
-    if resolved:
-        return resolved
-    try:
-        subprocess.run(
-            ["git", "remote", "set-head", remote_name, "-a"],
-            cwd=repo.working_tree_dir,
-            capture_output=True,
-            timeout=10,
-        )
-        return try_resolve()
-    except Exception:
-        return None
-
-
-def _get_dynamic_mainline(repo: git.Repo) -> str:
-    """
-    Detects the mainline branch name (e.g. 'main') dynamically.
-    Prioritizes remote-tracking HEAD, falls back to common names.
-    """
-    for remote in repo.remotes:
-        mainline_ref = _remote_head_mainline_ref(repo, remote.name)
-        if mainline_ref:
-            return mainline_ref.split("/", 1)[1]
-    ros_distro = os.environ.get("ROS_DISTRO", "").lower()
-    for candidate in [ros_distro, "main", "master"]:
-        if candidate and candidate in repo.heads:
-            return candidate
-    return "main"
-
-
-def _find_merge_evidence(
-    repo: git.Repo, branch: git.Head, mainline: str
-) -> Tuple[bool, str]:
-    try:
-        local_mainline = repo.heads[mainline]
-        tracking_ref = local_mainline.tracking_branch()
-        target = tracking_ref.name if tracking_ref else mainline
-
-        # 1. Direct Ancestry
-        if repo.is_ancestor(branch.commit, target):
-            return True, f"merged into {target}"
-
-        # 2. Squash Merge Search
-        since_date = branch.commit.committed_datetime.isoformat()
-        found = repo.git.log(
-            target,
-            f"--grep={branch.name}",
-            f"--since={since_date}",
-            "--format=%H",
-            "-n",
-            "1",
-        )
-        if found:
-            return True, f"merged into {target} (squashed)"
-
-        return False, f"merge into {target} unverified"
-    except Exception:
-        pass
-    return False, f"merge into {mainline} unverified"
-
-
-def _collect_repo_status(
-    repo_path: Path, workspace_root: Path, fetch: bool
-) -> RepoStatus:
-    rel_path = str(repo_path.relative_to(workspace_root))
-    try:
-        repo = Repo(repo_path)
-    except git.exc.InvalidGitRepositoryError:
-        return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
-
-    mainline = _get_dynamic_mainline(repo)
-    try:
-        branch_name = (
-            f"detached ({repo.head.commit.hexsha[:7]})"
-            if repo.head.is_detached
-            else repo.active_branch.name
-        )
-    except Exception:
-        branch_name = "unknown"
-
-    # local working tree status
-    changes_summary, mod_count, untracked_count = _collect_worktree_changes(repo)
-
-    # stashes
-    stash_count = 0
-    try:
-        stash_out = repo.git.stash("list")
-        stash_count = len(stash_out.splitlines()) if stash_out else 0
-    except git.exc.GitCommandError:
-        pass
-
-    unpushed, local_only, deleted_upstream = [], [], []
-    if fetch:
-        try:
-            # use subprocess for speed and timeout
-            subprocess.run(
-                ["git", "fetch", "--prune", "--all", "--quiet"],
-                cwd=str(repo_path),
-                capture_output=True,
-                timeout=30,
-            )
-        except Exception as e:
-            print_warn(f"Fetch failed for {rel_path}: {e}")
-
-        for branch in repo.branches:
-            tracking = branch.tracking_branch()
-            if not tracking:
-                if branch.name != mainline:
-                    local_only.append(branch.name)
-                continue
-
-            try:
-                # Use tracking.path (refs/remotes/...) to verify physical existence
-                repo.git.show_ref("--verify", tracking.path, with_exceptions=True)
-            except Exception:
-                _, hint = _find_merge_evidence(repo, branch, mainline)
-                deleted_upstream.append((branch.name, hint))
-                continue
-            try:
-                if (
-                    int(repo.git.rev_list("--count", f"{tracking.name}..{branch.name}"))
-                    > 0
-                ):
-                    unpushed.append(branch.name)
-            except Exception:
-                pass
-
-    has_changes = (
-        mod_count > 0
-        or untracked_count > 0
-        or stash_count > 0
-        or bool(unpushed)
-        or bool(local_only)
-        or bool(deleted_upstream)
-    )
-
-    return RepoStatus(
-        rel_path=rel_path,
-        branch=branch_name,
-        mainline=mainline,
-        is_git=True,
-        has_changes=has_changes,
-        untracked_count=untracked_count,
-        stash_count=stash_count,
-        unpushed_branches=unpushed,
-        local_only_branches=local_only,
-        deleted_upstream_branches=deleted_upstream,
-        changes_summary=changes_summary,
-        is_clean=not has_changes,
-    )
 
 
 def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool):
@@ -290,8 +46,9 @@ def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool)
     print_info(f"Status: {', '.join(labels)}")
     if status.has_changes:
         if fetched:
-            for b in status.unpushed_branches:
-                print_color(Colors.RED, f"  Unpushed: {b}")
+            for b, count in status.unpushed_branches:
+                commits_str = "commit" if count == 1 else "commits"
+                print_color(Colors.RED, f"  Unpushed: {b} ({count} {commits_str})")
             for b in status.local_only_branches:
                 print_color(Colors.LRED, f"  No Upstream: {b}")
             for b, hint in status.deleted_upstream_branches:
@@ -332,7 +89,7 @@ def remove_packages(
     for item in items:
         pkg_path_str = get_package_path(item, str(workspace_root))
         if pkg_path_str:
-            repo_root = _get_repo_root(Path(pkg_path_str), src_root)
+            repo_root = get_repo_root(Path(pkg_path_str), src_root)
             if not repo_root:
                 print_error(f"Package '{item}' is not in a git repo within {src_root}.")
                 return 1
@@ -347,7 +104,7 @@ def remove_packages(
         if not found_path:
             missing_items.append(item)
             continue
-        real_repo = _get_repo_root(found_path, src_root)
+        real_repo = get_repo_root(found_path, src_root)
         if not real_repo:
             print_error(f"Path '{item}' is not a git repository inside {src_root}.")
             return 1
@@ -373,8 +130,9 @@ def remove_packages(
 
     success = True
     for repo_root, packages in final_repos:
+        print_info(f"Collecting status for repo {repo_root}...")
         repo_rel = repo_root.relative_to(workspace_root)
-        status = _collect_repo_status(repo_root, workspace_root, fetch_remotes)
+        status = collect_repo_status(repo_root, workspace_root, fetch_remotes)
         _print_status_report(status, packages, fetched=fetch_remotes)
 
         unmerged_deleted = [

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -17,7 +17,12 @@ def remove_packages(
     workspace_root_str: str, items: List[str], fetch_remotes: bool = False
 ) -> int:
     """Remove specified items (packages or repositories) from the workspace.
-    Before removal, checks if the repository is dirty (uncommitted changes, unpushed commits, stash entries).
+
+    For git repositories, checks for dirty state (uncommitted changes, unpushed
+    commits, stash entries) and warns before deletion. For non-git targets
+    (loose directories under src/), warns explicitly that contents cannot be
+    recovered and requires confirmation.
+
     Args:
         workspace_root_str: Path to the workspace root as a string.
         items: List of package names or repository paths to remove.
@@ -28,110 +33,122 @@ def remove_packages(
     if not workspace_root_str:
         print_error("No workspace configured!")
         return 1
-    workspace_root, src_root = (
-        Path(workspace_root_str).resolve(),
-        (Path(workspace_root_str) / "src").resolve(),
-    )
     if not items:
-        print_error("No packages specified.")
+        print_error("No packages or repositories specified for removal.")
         return 1
 
-    items = list(dict.fromkeys(items))
-    repo_map, repos_explicitly_selected, missing_items = {}, set(), []
+    workspace_root = Path(workspace_root_str).resolve()
+    src_root = (workspace_root / "src").resolve()
 
-    # 1) Resolve items to repos
+    items = list(dict.fromkeys(items))
+    target_map = {}
+    targets_explicitly_selected = set()
+    non_git_targets = set()
+    missing_items = []
+
+    # 1) Resolve items to deletion targets (repo root if git, else item directory)
     for item in items:
         pkg_path_str = get_package_path(item, str(workspace_root))
         if pkg_path_str:
-            repo_root = get_repo_root(Path(pkg_path_str), src_root)
-            if not repo_root:
-                print_error(f"Package '{item}' is not in a git repo within {src_root}.")
-                return 1
-            repo_map.setdefault(repo_root, []).append(item)
+            pkg_path = Path(pkg_path_str)
+            repo_root = get_repo_root(pkg_path, src_root)
+            if repo_root:
+                target_map.setdefault(repo_root, []).append(item)
+            else:
+                target_map.setdefault(pkg_path, []).append(item)
+                non_git_targets.add(pkg_path)
             continue
-        candidate_ws, candidate_src = workspace_root / item, src_root / item
-        found_path = (
-            candidate_ws
-            if candidate_ws.is_dir()
-            else (candidate_src if candidate_src.is_dir() else None)
-        )
-        if not found_path:
+
+        candidate = src_root / item
+        if not candidate.is_dir():
             missing_items.append(item)
             continue
-        real_repo = get_repo_root(found_path, src_root)
-        if not real_repo:
-            print_error(f"Path '{item}' is not a git repository inside {src_root}.")
-            return 1
-        repos_explicitly_selected.add(real_repo)
-        repo_map.setdefault(real_repo, [])
+        real_repo = get_repo_root(candidate, src_root)
+        if real_repo:
+            targets_explicitly_selected.add(real_repo)
+            target_map.setdefault(real_repo, [])
+        else:
+            targets_explicitly_selected.add(candidate)
+            target_map.setdefault(candidate, [])
+            non_git_targets.add(candidate)
 
     if missing_items:
         print_error(f"Not found: {', '.join(missing_items)}")
         return 1
 
-    final_repos = []
-    for repo_root, requested in repo_map.items():
-        all_pkgs = find_packages_in_directory(str(repo_root))
-        if repo_root not in repos_explicitly_selected:
+    final_targets = []
+    for target_path, requested in target_map.items():
+        all_pkgs = find_packages_in_directory(str(target_path))
+        if target_path not in targets_explicitly_selected:
             extra = [p for p in all_pkgs if p not in requested]
             if extra:
+                kind = "Directory" if target_path in non_git_targets else "Repo"
                 print_warn(
-                    f"Repo '{repo_root.relative_to(workspace_root)}' contains other packages: {', '.join(extra)}"
+                    f"{kind} '{target_path.relative_to(workspace_root)}' contains other packages: {', '.join(extra)}"
                 )
-                if not confirm("Remove the entire repository and all these packages?"):
+                if not confirm(
+                    f"Remove all of {target_path.relative_to(workspace_root)}?"
+                ):
                     continue
-        final_repos.append((repo_root, all_pkgs))
+        final_targets.append((target_path, all_pkgs))
 
     success = True
-    for repo_root, packages in final_repos:
-        print_info(f"Collecting status for repo {repo_root}...")
-        repo_rel = repo_root.relative_to(workspace_root)
+    for target_path, packages in final_targets:
+        target_rel = target_path.relative_to(workspace_root)
+        is_non_git = target_path in non_git_targets
 
-        if fetch_remotes:
-            launch_subprocess(
-                ["git", "fetch", "--prune", "--all", "--quiet"],
-                cwd=repo_root,
-                timeout=180,
-            )  # Fetch is optional; failures handled gracefully by launch_subprocess
-
-        status = get_repo_status(repo_root, workspace_root)
-        print_repo_status(status, always_print_header=True)
-
-        print("Packages in this repo:")
-        for p in sorted(packages):
-            print(f"  - {p}")
-
-        if not status.is_git:
-            print_warn("Could not determine repository status.")
-            has_local_work = True  # Assume there might be local work
+        if is_non_git:
+            print_warn(
+                f"'{target_rel}' is not a git repository. "
+                "Its contents cannot be recovered after deletion."
+            )
+            has_local_work = True
         else:
-            unmerged_deleted = [
-                b
-                for b, hint in status.deleted_upstream_branches
-                if "merged" not in hint
-            ]
-            has_local_work = status.has_changes or bool(unmerged_deleted)
+            print_info(f"Collecting status for repo {target_path}...")
+            if fetch_remotes:
+                fetch_result = launch_subprocess(
+                    ["git", "fetch", "--prune", "--all", "--quiet"],
+                    cwd=target_path,
+                    timeout=180,
+                )
+                if fetch_result.returncode != 0:
+                    print_warn(
+                        "Failed to fetch remotes; "
+                        "merge / unpushed status may be stale."
+                    )
+            status = get_repo_status(target_path, workspace_root)
+            print_repo_status(status, always_print_header=True)
+            if not status.is_git:
+                # Defensive: get_repo_root validated this earlier; treat as risky.
+                has_local_work = True
+            else:
+                has_local_work = (
+                    status.has_changes or status.has_unmerged_deleted_branches
+                )
+
+        if packages:
+            print("Packages:")
+            for p in sorted(packages):
+                print(f"  - {p}")
 
         if has_local_work:
-            print_error(
-                "WARNING: local work will be lost (dirty/stash/unpushed/unmerged)."
-            )
-            if not confirm(f"Proceed with deletion of {repo_rel} anyway?"):
+            if not is_non_git:
+                print_error(
+                    "WARNING: local work will be lost (dirty/stash/unpushed/unmerged)."
+                )
+            if not confirm(f"Proceed with deletion of {target_rel} anyway?"):
                 continue
 
-        if not confirm(f"DELETE {repo_rel}?"):
+        if not confirm(f"DELETE {target_rel}?"):
             continue
 
-        # clean build artifacts first
         if packages:
-            if not clean_packages(str(workspace_root), packages, force=True):
-                print_error("Failed to clean build artifacts.")
-        # then delete the repo itself
-        print_info(f"Deleting {repo_rel}...")
+            clean_packages(str(workspace_root), packages, force=True)
+        print_info(f"Deleting {target_rel}...")
         try:
-            shutil.rmtree(repo_root)
+            shutil.rmtree(target_path)
             print_info("Deleted.")
         except OSError as e:
-            print_error(f"Failed to delete {repo_root}: {e}")
+            print_error(f"Failed to delete {target_path}: {e}")
             success = False
     return 0 if success else 1

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -50,17 +50,18 @@ def remove_packages(
     for item in items:
         pkg_path_str = get_package_path(item, str(workspace_root))
         if pkg_path_str:
-            pkg_path = Path(pkg_path_str)
-            repo_root = get_repo_root(pkg_path, src_root)
-            if repo_root:
-                target_map.setdefault(repo_root, []).append(item)
-            else:
-                target_map.setdefault(pkg_path, []).append(item)
-                non_git_targets.add(pkg_path)
-            continue
+            pkg_path = Path(pkg_path_str).resolve()
+            if pkg_path.is_relative_to(src_root):
+                repo_root = get_repo_root(pkg_path, src_root)
+                if repo_root:
+                    target_map.setdefault(repo_root, []).append(item)
+                else:
+                    target_map.setdefault(pkg_path, []).append(item)
+                    non_git_targets.add(pkg_path)
+                continue
 
-        candidate = src_root / item
-        if not candidate.is_dir():
+        candidate = (src_root / item).resolve()
+        if not candidate.is_relative_to(src_root) or not candidate.is_dir():
             missing_items.append(item)
             continue
         real_repo = get_repo_root(candidate, src_root)

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -1,11 +1,11 @@
 import shutil
-import subprocess
 from pathlib import Path
 from typing import List
 
 from .build import clean_packages
 from .git_utils import (
     get_repo_root,
+    launch_subprocess,
     print_repo_status,
 )
 from .print import confirm, print_error, print_info, print_warn
@@ -87,15 +87,11 @@ def remove_packages(
         repo_rel = repo_root.relative_to(workspace_root)
 
         if fetch_remotes:
-            try:
-                subprocess.run(
-                    ["git", "fetch", "--prune", "--all", "--quiet"],
-                    cwd=str(repo_root),
-                    capture_output=True,
-                    timeout=30,
-                )
-            except Exception:
-                pass  # Fetch is optional; proceed with local state
+            launch_subprocess(
+                ["git", "fetch", "--prune", "--all", "--quiet"],
+                cwd=repo_root,
+                timeout=30,
+            )  # Fetch is optional; failures handled gracefully by launch_subprocess
 
         status = print_repo_status(repo_root, workspace_root, always_print_header=True)
 
@@ -118,7 +114,9 @@ def remove_packages(
                 or bool(status.local_only_branches)
             )
         else:
-            has_local_work = False
+            # Failed to get status - warn user and require confirmation
+            print_warn("Could not determine repository status.")
+            has_local_work = True  # Assume there might be local work
 
         if has_local_work:
             print_error(

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -5,6 +5,7 @@ from typing import List
 from .build import clean_packages
 from .git_utils import (
     get_repo_root,
+    get_repo_status,
     launch_subprocess,
     print_repo_status,
 )
@@ -90,33 +91,26 @@ def remove_packages(
             launch_subprocess(
                 ["git", "fetch", "--prune", "--all", "--quiet"],
                 cwd=repo_root,
-                timeout=30,
+                timeout=180,
             )  # Fetch is optional; failures handled gracefully by launch_subprocess
 
-        status = print_repo_status(repo_root, workspace_root, always_print_header=True)
+        status = get_repo_status(repo_root, workspace_root)
+        print_repo_status(status, always_print_header=True)
 
         print("Packages in this repo:")
         for p in sorted(packages):
             print(f"  - {p}")
 
-        if status:
+        if not status.is_git:
+            print_warn("Could not determine repository status.")
+            has_local_work = True  # Assume there might be local work
+        else:
             unmerged_deleted = [
                 b
                 for b, hint in status.deleted_upstream_branches
                 if "merged" not in hint
             ]
-            has_local_work = (
-                bool(status.changes_summary)
-                or status.untracked_count > 0
-                or status.stash_count > 0
-                or bool(unmerged_deleted)
-                or bool(status.unpushed_branches)
-                or bool(status.local_only_branches)
-            )
-        else:
-            # Failed to get status - warn user and require confirmation
-            print_warn("Could not determine repository status.")
-            has_local_work = True  # Assume there might be local work
+            has_local_work = status.has_changes or bool(unmerged_deleted)
 
         if has_local_work:
             print_error(

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -1,76 +1,29 @@
 import shutil
+import subprocess
 from pathlib import Path
 from typing import List
 
 from .build import clean_packages
-from .git_helpers import (
-    RepoStatus,
-    collect_repo_status,
+from .git_utils import (
     get_repo_root,
-    find_merge_evidence,
+    print_repo_status,
 )
-from .print import Colors, confirm, print_error, print_info, print_warn, print_color
+from .print import confirm, print_error, print_info, print_warn
 from .workspace import find_packages_in_directory, get_package_path
-
-try:
-    import git
-except ImportError:
-    print_error("GitPython is required! Install using 'pip install gitpython'")
-    raise
-
-
-def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool):
-    print_info(
-        f"Repo: {status.rel_path} (local: {status.branch} | mainline: {status.mainline})"
-    )
-    if not status.is_git:
-        print_warn("  [!] Not a git repository")
-        return
-
-    labels = []
-    if status.is_clean:
-        labels.append("Clean")
-    else:
-        if status.changes_summary or status.untracked_count:
-            labels.append("Working tree dirty")
-        if status.stash_count:
-            labels.append("Stashed changes")
-        if fetched:
-            if status.unpushed_branches:
-                labels.append("Unpushed commits")
-            if status.local_only_branches:
-                labels.append("Local-only branches")
-            if status.deleted_upstream_branches:
-                labels.append("Upstream missing")
-
-    print_info(f"Status: {', '.join(labels)}")
-    if status.has_changes:
-        if fetched:
-            for b, count in status.unpushed_branches:
-                commits_str = "commit" if count == 1 else "commits"
-                print_color(Colors.RED, f"  Unpushed: {b} ({count} {commits_str})")
-            for b in status.local_only_branches:
-                print_color(Colors.LRED, f"  No Upstream: {b}")
-            for b, hint in status.deleted_upstream_branches:
-                color = Colors.GREEN if "merged" in hint else Colors.YELLOW
-                print_color(color, f"  Upstream Missing: {b} ({hint})")
-        else:
-            print_color(Colors.LGRAY, "  (Hint: run with fetch_remotes=True)")
-
-        for change in status.changes_summary[:50]:
-            print_color(Colors.ORANGE, f"  {change}")
-        if status.untracked_count:
-            print_color(Colors.LGRAY, f"  {status.untracked_count} untracked files")
-        if status.stash_count:
-            print_color(Colors.LGRAY, f"  {status.stash_count} stash entries")
-    print("Packages in this repo:")
-    for p in sorted(packages):
-        print(f"  - {p}")
 
 
 def remove_packages(
     workspace_root_str: str, items: List[str], fetch_remotes: bool = False
 ) -> int:
+    """Remove specified items (packages or repositories) from the workspace.
+    Before removal, checks if the repository is dirty (uncommitted changes, unpushed commits, stash entries).
+    Args:
+        workspace_root_str: Path to the workspace root as a string.
+        items: List of package names or repository paths to remove.
+        fetch_remotes: Whether to fetch remotes before checking mainline merge state.
+    Returns:
+        0 on success, 1 on failure.
+    """
     if not workspace_root_str:
         print_error("No workspace configured!")
         return 1
@@ -132,20 +85,40 @@ def remove_packages(
     for repo_root, packages in final_repos:
         print_info(f"Collecting status for repo {repo_root}...")
         repo_rel = repo_root.relative_to(workspace_root)
-        status = collect_repo_status(repo_root, workspace_root, fetch_remotes)
-        _print_status_report(status, packages, fetched=fetch_remotes)
 
-        unmerged_deleted = [
-            b for b, hint in status.deleted_upstream_branches if "merged" not in hint
-        ]
-        has_local_work = (
-            bool(status.changes_summary)
-            or status.untracked_count > 0
-            or status.stash_count > 0
-            or bool(unmerged_deleted)
-            or bool(status.unpushed_branches)
-            or bool(status.local_only_branches)
-        )
+        if fetch_remotes:
+            try:
+                subprocess.run(
+                    ["git", "fetch", "--prune", "--all", "--quiet"],
+                    cwd=str(repo_root),
+                    capture_output=True,
+                    timeout=30,
+                )
+            except Exception:
+                pass
+
+        status = print_repo_status(repo_root, workspace_root, always_print_header=True)
+
+        print("Packages in this repo:")
+        for p in sorted(packages):
+            print(f"  - {p}")
+
+        if status:
+            unmerged_deleted = [
+                b
+                for b, hint in status.deleted_upstream_branches
+                if "merged" not in hint
+            ]
+            has_local_work = (
+                bool(status.changes_summary)
+                or status.untracked_count > 0
+                or status.stash_count > 0
+                or bool(unmerged_deleted)
+                or bool(status.unpushed_branches)
+                or bool(status.local_only_branches)
+            )
+        else:
+            has_local_work = False
 
         if has_local_work:
             print_error(

--- a/tuda_workspace_scripts/remove.py
+++ b/tuda_workspace_scripts/remove.py
@@ -32,7 +32,8 @@ class RepoStatus:
     # only meaningful if fetch_remotes=True
     unpushed_branches: List[str] = field(default_factory=list)
     local_only_branches: List[str] = field(default_factory=list)
-    deleted_upstream_branches: List[str] = field(default_factory=list)
+    # Stores tuples of (branch_name, merge_hint)
+    deleted_upstream_branches: List[Tuple[str, str]] = field(default_factory=list)
 
     is_clean: bool = True
 
@@ -67,7 +68,7 @@ def _get_repo_root(path: Path, workspace_src: Path) -> Optional[Path]:
 def _collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
     """
     Return (changes_summary, modified_count, untracked_count) using
-    `git status --porcelain` (robust, fast, works even if HEAD is unborn).
+    `git status --porcelain`.
     """
     try:
         out = repo.git.status("--porcelain=v1").splitlines()
@@ -106,6 +107,86 @@ def _collect_worktree_changes(repo: Repo) -> Tuple[List[str], int, int]:
     return changes_summary, modified_count, untracked_count
 
 
+def _remote_head_mainline_ref(repo: git.Repo, remote_name: str) -> str | None:
+    """
+    Resolve the remote's configured mainline via refs/remotes/<remote>/HEAD.
+    Returns a ref like '<remote>/<branch>' (e.g. 'origin/ros2') or None.
+    """
+    head_ref = f"refs/remotes/{remote_name}/HEAD"
+    try:
+        sym = repo.git.symbolic_ref("-q", head_ref).strip()
+        if not sym:
+            return None
+        prefix = f"refs/remotes/{remote_name}/"
+        if sym.startswith(prefix):
+            return f"{remote_name}/{sym[len(prefix):]}"
+        return None
+    except git.exc.GitCommandError:
+        return None
+
+
+def _get_dynamic_mainline(repo: git.Repo) -> str:
+    """
+    Detects the mainline branch name (e.g. 'main') dynamically.
+    Prioritizes remote-tracking HEAD, falls back to common names.
+    """
+    for remote in repo.remotes:
+        mainline_ref = _remote_head_mainline_ref(repo, remote.name)
+        if mainline_ref:
+            return mainline_ref.split("/", 1)[1]
+
+    for candidate in ["main", "master", "develop"]:
+        if candidate in repo.heads:
+            return candidate
+    return "main"
+
+
+def _find_merge_evidence(repo: git.Repo, branch: git.Head, mainline: str) -> str:
+    """
+    Determines if a branch was merged into the remote mainline or abandoned.
+    Tests for direct ancestry and squashed commit messages against the remote ref.
+    """
+    try:
+        # 1. Resolve the tracking branch for mainline (e.g., 'main' -> 'origin/main')
+        local_mainline = repo.heads[mainline]
+        tracking_ref = local_mainline.tracking_branch()
+        print(
+            f"Debug: Checking merge evidence for branch {branch.name} against mainline {mainline} (tracking: {tracking_ref})"
+        )
+
+        # If no tracking branch exists, fall back to local mainline for the check
+        # 'target' will be a string like 'origin/main' or 'main'
+        target = tracking_ref.name if tracking_ref else mainline
+
+        # 2. Direct Ancestry (Standard Merge or Rebase)
+        # Check if the branch commit is an ancestor of the remote mainline tip
+        if repo.is_ancestor(branch.commit, target):
+            return f"merged into {target}"
+
+        # 3. Squash Merge Search
+        # Limits search to remote mainline commits after the branch's last activity
+        since_date = branch.commit.committed_datetime.isoformat()
+
+        found_commit = repo.git.log(
+            target,
+            f"--grep={branch.name}",
+            f"--since={since_date}",
+            "--format=%H",
+            "-n",
+            "1",
+        )
+
+        if found_commit:
+            return f"merged into {target} (squashed)"
+
+    except Exception as e:
+        # Useful for debugging why a specific check failed
+        # print(f"Debug: Evidence check failed for {branch.name}: {e}")
+        pass
+
+    return "probably abandoned"
+
+
 def _collect_repo_status(
     repo_path: Path, workspace_root: Path, fetch: bool
 ) -> RepoStatus:
@@ -116,7 +197,8 @@ def _collect_repo_status(
     except git.exc.InvalidGitRepositoryError:
         return RepoStatus(rel_path=rel_path, branch="unknown", is_git=False)
 
-    # Branch info
+    mainline = _get_dynamic_mainline(repo)
+
     try:
         if repo.head.is_detached:
             branch_name = f"detached ({repo.head.commit.hexsha[:7]})"
@@ -139,7 +221,7 @@ def _collect_repo_status(
     # remote-related checks only if fetch=True (avoid lying when refs are stale)
     unpushed: List[str] = []
     local_only: List[str] = []
-    deleted_upstream: List[str] = []
+    deleted_upstream: List[Tuple[str, str]] = []
 
     if fetch:
         for remote in repo.remotes:
@@ -151,18 +233,17 @@ def _collect_repo_status(
         for branch in repo.branches:
             tracking = branch.tracking_branch()
             if not tracking:
-                local_only.append(branch.name)
+                if branch.name != mainline:
+                    local_only.append(branch.name)
                 continue
 
-            # Verify the tracking reference actually exists in the local git store
             try:
-                # tracking.path returns the full string like 'refs/remotes/origin/main'
-                print(tracking.path)
+                # Use tracking.path (refs/remotes/...) to verify physical existence
                 repo.git.show_ref("--verify", tracking.path, with_exceptions=True)
-                print(f"Verified tracking ref {tracking.path} for branch {branch.name}")
             except Exception:
-                # If we fetched and the ref is gone, the upstream branch was likely deleted
-                deleted_upstream.append(branch.name)
+                # Upstream is gone: try to find out if it was merged
+                hint = _find_merge_evidence(repo, branch, mainline)
+                deleted_upstream.append((branch.name, hint))
                 continue
 
             try:
@@ -220,14 +301,6 @@ def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool)
                 labels.append("Local-only branches")
             if status.deleted_upstream_branches:
                 labels.append("Upstream missing")
-        else:
-            if (
-                status.unpushed_branches
-                or status.local_only_branches
-                or status.deleted_upstream_branches
-            ):
-                # shouldn't happen, but keep logic consistent
-                labels.append("Remote status unknown")
 
     print_info(f"Status: {', '.join(labels)}")
 
@@ -237,21 +310,16 @@ def _print_status_report(status: RepoStatus, packages: List[str], fetched: bool)
                 print_color(Colors.RED, f"  Unpushed: {b}")
             for b in status.local_only_branches:
                 print_color(Colors.LRED, f"  No Upstream: {b}")
-            for b in status.deleted_upstream_branches:
-                print_color(Colors.YELLOW, f"  Upstream Missing: {b}")
+            for b, hint in status.deleted_upstream_branches:
+                color = Colors.GREEN if "merged" in hint else Colors.YELLOW
+                print_color(color, f"  Upstream Missing: {b} ({hint})")
         else:
-            # gentle hint
-            print_color(
-                Colors.LGRAY,
-                "  (Hint: run with fetch_remotes=True to check upstream state)",
-            )
+            print_color(Colors.LGRAY, "  (Hint: run with fetch_remotes=True)")
 
         for change in status.changes_summary[:50]:
             print_color(Colors.ORANGE, f"  {change}")
         if len(status.changes_summary) > 50:
-            print_color(
-                Colors.LGRAY, f"  ... +{len(status.changes_summary) - 50} more changes"
-            )
+            print_color(Colors.LGRAY, f"  ... +{len(status.changes_summary) - 50} more")
 
         if status.untracked_count:
             print_color(Colors.LGRAY, f"  {status.untracked_count} untracked files")
@@ -277,8 +345,7 @@ def remove_packages(
         print_error("No packages specified.")
         return 1
 
-    items = list(dict.fromkeys(items))  # deduplicate while preserving order
-
+    items = list(dict.fromkeys(items))
     repo_map: Dict[Path, List[str]] = {}
     repos_explicitly_selected: Set[Path] = set()
     missing_items: List[str] = []
@@ -286,7 +353,6 @@ def remove_packages(
     # 1) Resolve items to repos
     for item in items:
         pkg_path_str = get_package_path(item, str(workspace_root))
-
         if pkg_path_str:
             repo_root = _get_repo_root(Path(pkg_path_str), src_root)
             if not repo_root:
@@ -300,12 +366,9 @@ def remove_packages(
         # treat as path (relative to ws or src)
         candidate_ws = workspace_root / item
         candidate_src = src_root / item
-
-        found_path: Optional[Path] = None
-        if candidate_ws.is_dir():
-            found_path = candidate_ws
-        elif candidate_src.is_dir():
-            found_path = candidate_src
+        found_path = next(
+            (p for p in [candidate_ws, candidate_src] if p.is_dir()), None
+        )
 
         if not found_path:
             missing_items.append(item)
@@ -325,10 +388,8 @@ def remove_packages(
 
     # 2) Determine final repos and packages to clean
     final_repos_to_process: List[Tuple[Path, List[str]]] = []
-
     for repo_root, requested_pkgs in repo_map.items():
         all_pkgs_in_repo = find_packages_in_directory(str(repo_root))
-
         if repo_root in repos_explicitly_selected:
             final_repos_to_process.append((repo_root, all_pkgs_in_repo))
             continue
@@ -337,21 +398,17 @@ def remove_packages(
         if extra_pkgs:
             repo_rel = repo_root.relative_to(workspace_root)
             print_warn(
-                f"Repository '{repo_rel}' contains other packages: {', '.join(extra_pkgs)}"
+                f"Repo '{repo_rel}' contains other packages: {', '.join(extra_pkgs)}"
             )
             if not confirm("Remove the entire repository and all these packages?"):
-                print_info("Skipping.")
                 continue
-
         final_repos_to_process.append((repo_root, all_pkgs_in_repo))
 
-    # 3) Execute deletions
-    sucess = True
+    success = True
     for repo_root, packages in final_repos_to_process:
         repo_root = repo_root.resolve()
         repo_rel = repo_root.relative_to(workspace_root)
 
-        # final safety guard
         if not repo_root.is_relative_to(src_root):
             print_error(
                 f"SAFETY GUARD: Refusing to delete {repo_root} (outside {src_root})"
@@ -361,15 +418,27 @@ def remove_packages(
         status = _collect_repo_status(repo_root, workspace_root, fetch_remotes)
         _print_status_report(status, packages, fetched=fetch_remotes)
 
-        # Decide whether to warn
-        has_uncommitted = bool(status.changes_summary) or status.untracked_count > 0
-        has_local_work = has_uncommitted or (status.stash_count > 0)
+        # Logic: Don't consider a branch "lost work" if it's already merged
         has_unpushed = bool(status.unpushed_branches) or bool(
             status.local_only_branches
         )
 
+        # Only warn for deleted upstreams that aren't merged
+        unmerged_deleted = [
+            b for b, hint in status.deleted_upstream_branches if "merged" not in hint
+        ]
+
+        has_local_work = (
+            bool(status.changes_summary)
+            or status.untracked_count > 0
+            or status.stash_count > 0
+            or bool(unmerged_deleted)
+        )
+
         if has_local_work or has_unpushed:
-            print_error("WARNING: local work will be lost (dirty/stash/unpushed).")
+            print_error(
+                "WARNING: local work will be lost (dirty/stash/unpushed/unmerged)."
+            )
             if not confirm(f"Proceed with deletion of {repo_rel} anyway?"):
                 continue
 
@@ -387,6 +456,6 @@ def remove_packages(
             print_info("Deleted.")
         except OSError as e:
             print_error(f"Failed to delete {repo_root}: {e}")
-            sucess = False
+            success = False
 
-    return 0 if sucess else 1
+    return 0 if success else 1

--- a/tuda_workspace_scripts/workspace.py
+++ b/tuda_workspace_scripts/workspace.py
@@ -113,7 +113,8 @@ def get_repos_in_workspace(workspace_path=None):
         # Check for Git repository
         if ".git" in dirnames:
             repos.append(dirpath)
-            dirnames.remove(".git")
+            dirnames[:] = []  # Don't recurse into the repo
+            continue
         dirnames[:] = [d for d in dirnames if not d.startswith(".")]
     return repos
 
@@ -213,11 +214,11 @@ class CombinedPackageReposCompleter:
         if self.workspace_path is None:
             return []
         packages = get_packages_in_workspace(self.workspace_path)
-        repos = []
-        for repo_path in get_repos_in_workspace(self.workspace_path):
-            repo_name = os.path.basename(repo_path)
-            repos.append(repo_name)
-        return packages + repos
+        repos = {
+            os.path.basename(repo_path)
+            for repo_path in get_repos_in_workspace(self.workspace_path)
+        }
+        return list(set(packages) | repos)
 
 
 if __name__ == "__main__":

--- a/tuda_workspace_scripts/workspace.py
+++ b/tuda_workspace_scripts/workspace.py
@@ -93,8 +93,7 @@ def get_packages_in_workspace(workspace_path=None):
 def get_repos_in_workspace(workspace_path=None):
     """
     Looks for git repositories in the src folder of a workspace.
-    :param workspace_path: Path to the workspace root (The parent directory of the src folder).
-        If None will use get_workspace_root() to try to find it.
+    :param workspace_path: Path to the workspace root.
     """
     if workspace_path is None:
         workspace_path = get_workspace_root()
@@ -102,7 +101,16 @@ def get_repos_in_workspace(workspace_path=None):
             return []
     repos = []
     src_path = os.path.join(workspace_path, "src")
+    # Track visited real paths to prevent redundant traversal and symlink cycles
+    visited_paths = set()
     for dirpath, dirnames, _ in os.walk(src_path, followlinks=True):
+        real_dirpath = os.path.realpath(dirpath)
+
+        if real_dirpath in visited_paths:
+            del dirnames[:]  # Stop recursion here
+            continue
+        visited_paths.add(real_dirpath)
+        # Check for Git repository
         if ".git" in dirnames:
             repos.append(dirpath)
             dirnames.remove(".git")

--- a/tuda_workspace_scripts/workspace.py
+++ b/tuda_workspace_scripts/workspace.py
@@ -218,7 +218,7 @@ class CombinedPackageReposCompleter:
             os.path.basename(repo_path)
             for repo_path in get_repos_in_workspace(self.workspace_path)
         }
-        return list(set(packages) | repos)
+        return sorted(set(packages) | repos)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a `remove` command to completely delete packages or repositories from the workspace, automatically handling the cleanup of source, build, and install directories.

### Features:

* Accepts specific package names, repository names, or the --this flag (current directory).
* Scans for uncommitted changes, stashed files, or unpushed commits, warning the user before deletion.
* Detects multi-package repositories and prompts for confirmation if deleting a repo would remove additional packages not explicitly requested.

### Usage:

* `tuda_wss remove my_package my_repo_name`
* `ws remove --this`