### PR TITLE
Update discovery config instead of replacing it.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>ament_index_python</depend>
   <depend>python3-git</depend>
   <depend>python3-jinja2</depend>
+  <depend>python3-json5</depend>
   <depend>python3-libtmux</depend>
   <depend>python3-yaml</depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -92,18 +92,25 @@ Examples: hostname 10.0.10.3
     selected_robots = args.robots
     custom_addresses = args.address or []
 
-    # Validation logic
     if not selected_robots and not custom_addresses:
-        parser.error("You must specify either 'robots' or '--address'.")
+        # No argument provided, print current endpoints
+        robots = get_connected_robots()
+        if not robots:
+            print("No endpoints connected.")
+            return
+        print("Connected endpoints:")
+        for robot in robots:
+            print(f" - {robot}")
+        return
 
+    # Validation logic
     if "off" in selected_robots and len(selected_robots) > 1:
         parser.error("'off' cannot be combined with other robots.")
 
-    # Disallow "all" with any other options
     if "all" in selected_robots and len(selected_robots) > 1:
         parser.error("'all' cannot be combined with other robots.")
 
-    create_discovery_config(selected_robots, custom_addresses)
+    update_discovery_config(selected_robots, custom_addresses)
 
     # Get hooks and sort them by their filename
     hooks = list(sorted(get_hooks_for_command("discovery"), key=basename))
@@ -121,6 +128,15 @@ Examples: hostname 10.0.10.3
             subprocess.run(
                 [executable, hook] + selected_robots, cwd=get_workspace_root()
             )
+
+    print_info("Discovery configuration updated.")
+    print_header("Connected endpoints:")
+    robots = get_connected_robots()
+    if not robots:
+        print("No endpoints connected.")
+        return
+    for robot in robots:
+        print(f" - {robot}")
 
 
 if __name__ == "__main__":

--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -1,6 +1,7 @@
 from ament_index_python.packages import get_package_share_directory
 import re
 import os
+import json
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from .print import print_info, print_warn
@@ -33,6 +34,45 @@ def create_discovery_config(selected_robots: list[str], custom_addresses: list[s
         )
     elif RMW:
         raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
+    else:
+        raise RuntimeError("RMW_IMPLEMENTATION is not set.")
+
+
+def update_discovery_config(selected_robots: list[str], custom_addresses: list[str]):
+    available_robots = load_robots()
+
+    if RMW == "rmw_zenoh_cpp":
+        update_zenoh_router_config(selected_robots, available_robots, custom_addresses)
+    elif RMW == "rmw_cyclonedds_cpp":
+        print_warn(
+            "Updating Cyclone DDS config is not supported. Overwriting the config file instead."
+        )
+        create_cyclonedds_router_config_xml(
+            selected_robots, available_robots, custom_addresses
+        )
+    elif RMW:
+        raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
+    else:
+        raise RuntimeError("RMW_IMPLEMENTATION is not set.")
+
+
+def get_connected_robots() -> list[str]:
+    available_robots = load_robots()
+    if RMW == "rmw_zenoh_cpp":
+        routers = get_zenoh_routers_from_config_file(ZENOH_ROUTER_CONFIG_PATH)
+        connected_robots = []
+        for router in routers:
+            for robot_name, robot_data in available_robots.items():
+                if any(
+                    router.get_zenoh_router_address() == r.get_zenoh_router_address()
+                    for r in robot_data.zenoh_routers
+                ):
+                    connected_robots.append(robot_name)
+        return connected_robots
+    elif RMW:
+        raise NotImplementedError(
+            f"Listing the currently connected robots is not implemented for RMW {RMW}"
+        )
     else:
         raise RuntimeError("RMW_IMPLEMENTATION is not set.")
 
@@ -103,11 +143,11 @@ def create_cyclonedds_router_config_xml(
     print_info(f"Cyclone DDS config updated.")
 
 
-def create_zenoh_router_config_yaml(
+def _create_zenoh_router_list(
     selected_robots: list[str],
     available_robots: dict[str, Robot],
     custom_addresses: list[str],
-):
+) -> list[ZenohRouter]:
     routers = []
 
     for name in selected_robots:
@@ -125,24 +165,41 @@ def create_zenoh_router_config_yaml(
             )
 
     for address in custom_addresses:
-        match = re.match(r"([^:/]+)(:\d+)?(/.*)?$", address)
-        if not match:
-            print_warn(
-                f"Invalid address '{address}'! Please use the format 'IP_OR_HOSTNAME[:PORT][/PROTOCOL]'."
-            )
-            continue
-        name = match.group(1)
-        tmp = match.group(2)
-        port = int(tmp[1:]) if tmp and tmp[0] == ":" else 7447
-        tmp = match.group(3)
-        protocol = tmp[1:] if tmp and tmp[0] == "/" else "tcp"
+        routers.append(ZenohRouter.from_string(address))
 
-        routers.append(ZenohRouter(name, port, protocol))
+    return routers
+
+
+def get_zenoh_routers_from_config_file(config_path: str) -> list[ZenohRouter]:
+    if config_path.endswith((".yaml", ".yml")):
+        with open(config_path, "r") as file:
+            config = yaml.safe_load(file)
+        routers = []
+        for endpoint in config.get("connect", {}).get("endpoints", []):
+            routers.append(ZenohRouter.from_string(endpoint))
+        return routers
+    elif config_path.endswith((".json", ".json5")):
+        with open(config_path, "r") as file:
+            config = json.load(file)
+        routers = []
+        for endpoint in config.get("connect", {}).get("endpoints", []):
+            routers.append(ZenohRouter.from_string(endpoint))
+        return routers
+    raise ValueError(
+        f"Unsupported config file format: {config_path}. Supported formats are .yaml, .yml, .json, and .json5."
+    )
+
+
+def create_zenoh_router_config_yaml(
+    selected_robots: list[str],
+    available_robots: dict[str, Robot],
+    custom_addresses: list[str],
+):
+    routers = _create_zenoh_router_list(
+        selected_robots, available_robots, custom_addresses
+    )
 
     config = _create_zenoh_router_config_yaml(routers)
-    print("Connecting to routers:")
-    for router in config["connect"]["endpoints"]:
-        print(" -", router)
 
     if os.path.isfile(ZENOH_ROUTER_CONFIG_PATH):
         # Backup existing files if not ours
@@ -162,6 +219,55 @@ def create_zenoh_router_config_yaml(
         file.write(f"{YAML_MARKER}\n")
         yaml.dump(config, file, default_flow_style=False)
     print_info(f"Zenoh router config updated.")
+
+
+def update_zenoh_router_config(
+    selected_robots: list[str],
+    available_robots: dict[str, Robot],
+    custom_addresses: list[str],
+):
+    if not ZENOH_ROUTER_CONFIG_PATH:
+        print_warn("ZENOH_ROUTER_CONFIG_URI is not set. Cannot update config file.")
+        return
+    if not ZENOH_ROUTER_CONFIG_PATH.endswith((".yaml", ".yml", ".json", ".json5")):
+        print_warn(
+            f"Unsupported config file format: {ZENOH_ROUTER_CONFIG_PATH}. Supported formats are .yaml, .yml, .json, and .json5. Cannot update config file."
+        )
+        return
+    routers = _create_zenoh_router_list(
+        selected_robots, available_robots, custom_addresses
+    )
+
+    config = {
+        "mode": "router",
+        "connect": {"endpoints": []},
+    }
+    if not os.path.isfile(ZENOH_ROUTER_CONFIG_PATH):
+        print_warn(
+            f"Zenoh router config file not found at {ZENOH_ROUTER_CONFIG_PATH}. Creating new config file."
+        )
+    if ZENOH_ROUTER_CONFIG_PATH.endswith((".yaml", ".yml")):
+        if os.path.isfile(ZENOH_ROUTER_CONFIG_PATH):
+            with open(ZENOH_ROUTER_CONFIG_PATH, "r") as file:
+                config = yaml.safe_load(file)
+        if not config["connect"]:
+            config["connect"] = {}
+        config["connect"]["endpoints"] = [
+            router.get_zenoh_router_address() for router in routers
+        ]
+        with open(ZENOH_ROUTER_CONFIG_PATH, "w") as file:
+            yaml.dump(config, file, default_flow_style=False)
+    elif ZENOH_ROUTER_CONFIG_PATH.endswith((".json", ".json5")):
+        if os.path.isfile(ZENOH_ROUTER_CONFIG_PATH):
+            with open(ZENOH_ROUTER_CONFIG_PATH, "r") as file:
+                config = json.load(file)
+        if not config["connect"]:
+            config["connect"] = {}
+        config["connect"]["endpoints"] = [
+            router.get_zenoh_router_address() for router in routers
+        ]
+        with open(ZENOH_ROUTER_CONFIG_PATH, "w") as file:
+            json.dump(config, file)
 
 
 def _create_cyclonedds_config_xml(peers: list[str]) -> str:

--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -2,6 +2,7 @@ from ament_index_python.packages import get_package_share_directory
 import re
 import os
 import json
+import json5
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from .print import print_info, print_warn
@@ -180,7 +181,7 @@ def get_zenoh_routers_from_config_file(config_path: str) -> list[ZenohRouter]:
         return routers
     elif config_path.endswith((".json", ".json5")):
         with open(config_path, "r") as file:
-            config = json.load(file)
+            config = json5.load(file)
         routers = []
         for endpoint in config.get("connect", {}).get("endpoints", []):
             routers.append(ZenohRouter.from_string(endpoint))
@@ -260,14 +261,17 @@ def update_zenoh_router_config(
     elif ZENOH_ROUTER_CONFIG_PATH.endswith((".json", ".json5")):
         if os.path.isfile(ZENOH_ROUTER_CONFIG_PATH):
             with open(ZENOH_ROUTER_CONFIG_PATH, "r") as file:
-                config = json.load(file)
+                config = json5.load(file)
         if not config["connect"]:
             config["connect"] = {}
         config["connect"]["endpoints"] = [
             router.get_zenoh_router_address() for router in routers
         ]
         with open(ZENOH_ROUTER_CONFIG_PATH, "w") as file:
-            json.dump(config, file)
+            if ZENOH_ROUTER_CONFIG_PATH.endswith(".json5"):
+                json5.dump(config, file, indent=2)
+            else:
+                json.dump(config, file, indent=2)
 
 
 def _create_cyclonedds_config_xml(peers: list[str]) -> str:

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -1,6 +1,7 @@
 from .workspace import get_workspace_root
 import os
 from jinja2 import Template
+import re
 from typing import Any, Generator
 import yaml
 
@@ -85,6 +86,21 @@ class ZenohRouter:
 
     def get_zenoh_router_address(self):
         return f"{self.protocol}/{self.address}:{self.port}"
+
+    @staticmethod
+    def from_string(addr: str):
+        """
+        Creates a ZenohRouter objects from the text representation "protocol/address:port"
+        Example: "tcp/192.168.1.100:7447" or "quic/athena-main:7447"
+        """
+        pattern = r"^(?P<protocol>\w+)\/(?P<address>[\w\.\-]+):(?P<port>\d+)$"
+        match = re.match(pattern, addr)
+        if not match:
+            raise ValueError(f"Invalid Zenoh router address format: {addr}")
+        protocol = match.group("protocol")
+        address = match.group("address")
+        port = int(match.group("port"))
+        return ZenohRouter(address, port, protocol)
 
 
 class Robot:


### PR DESCRIPTION
Prints the connected endpoints if no argument provided.
Config is now updated, keeping all other settings identical, instead of replacing the file.