### PR TITLE
Add option to list tests and filter for a specific test.

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -15,7 +15,7 @@ import sys
 
 def main():
     workspace_root = get_workspace_root()
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     packages_arg = parser.add_argument(
         "packages", nargs="*", help="If specified only these packages are built."
     )
@@ -59,7 +59,13 @@ def main():
         "--filter",
         "-k",
         type=str,
-        help="Only run tests matching the given pattern (ctest -R, pytest -k).",
+        help=(
+            "Only run tests matching the given pattern. Forwarded to\n"
+            "ctest -R (regex) and pytest -k (expression); syntax differs:\n"
+            "  Single test:    --filter TestPrefix.MyTestName\n"
+            '  Multiple tests: --filter "TestA|TestB" (ctest) or "TestA or TestB" (pytest)\n'
+            "  Substring:      --filter TestPrefix"
+        ),
     )
 
     argcomplete.autocomplete(parser)
@@ -124,7 +130,10 @@ def main():
         print_error(">>> Failed to build packages")
         exit(returncode)
 
-    print_info(">>> Running tests")
+    if args.list_tests:
+        print_info(">>> Listing tests")
+    else:
+        print_info(f">>> Running tests{' (filtered)' if args.filter else ''}")
     colcon_test_args = []
     if build_folder is not None:
         colcon_test_args.extend(["--build-base", build_folder])
@@ -134,6 +143,7 @@ def main():
         colcon_test_args.extend(["--packages-select"] + packages)
 
     if args.list_tests:
+        # Leading space on -N / --collect-only avoids colcon parsing them as its own args.
         colcon_test_args.extend(["--ctest-args", " -N"])
         colcon_test_args.extend(["--pytest-args", " --collect-only"])
         colcon_test_args.extend(["--event-handlers", "console_direct+"])
@@ -141,8 +151,9 @@ def main():
         colcon_test_args.extend(["--ctest-args", f" -R {args.filter}"])
         colcon_test_args.extend(["--pytest-args", f" -k {args.filter}"])
 
-    print_info(">>> Cleaning old test results")
-    clean_test_results(workspace_root, packages, build_folder)
+    if not args.list_tests:
+        print_info(">>> Cleaning old test results")
+        clean_test_results(workspace_root, packages, build_folder)
 
     colcon_command = (
         f". {install_folder}/setup.sh && colcon test {' '.join(colcon_test_args)}"

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-from tuda_workspace_scripts.build import build_packages, clean_packages
+from tuda_workspace_scripts.build import (
+    build_packages,
+    clean_packages,
+    clean_test_results,
+)
 from tuda_workspace_scripts.print import *
 from tuda_workspace_scripts.workspace import *
 import argcomplete
@@ -8,7 +12,8 @@ import os
 import subprocess
 import sys
 
-if __name__ == "__main__":
+
+def main():
     workspace_root = get_workspace_root()
     parser = argparse.ArgumentParser()
     packages_arg = parser.add_argument(
@@ -42,6 +47,19 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
         help="Automatically answer yes to all questions.",
+    )
+    parser.add_argument(
+        "--list-tests",
+        "-l",
+        default=False,
+        action="store_true",
+        help="List the tests instead of running them.",
+    )
+    parser.add_argument(
+        "--filter",
+        "-k",
+        type=str,
+        help="Only run tests matching the given pattern (ctest -R, pytest -k).",
     )
 
     argcomplete.autocomplete(parser)
@@ -115,8 +133,23 @@ if __name__ == "__main__":
     if len(packages) > 0:
         colcon_test_args.extend(["--packages-select"] + packages)
 
+    if args.list_tests:
+        colcon_test_args.extend(["--ctest-args", " -N"])
+        colcon_test_args.extend(["--pytest-args", " --collect-only"])
+        colcon_test_args.extend(["--event-handlers", "console_direct+"])
+    elif args.filter:
+        colcon_test_args.extend(["--ctest-args", f" -R {args.filter}"])
+        colcon_test_args.extend(["--pytest-args", f" -k {args.filter}"])
+
+    print_info(">>> Cleaning old test results")
+    clean_test_results(workspace_root, packages, build_folder)
+
+    colcon_command = (
+        f". {install_folder}/setup.sh && colcon test {' '.join(colcon_test_args)}"
+    )
+    print_info(f">>> Command: {colcon_command}")
     command = subprocess.run(
-        f". {install_folder}/setup.sh && colcon test {' '.join(colcon_test_args)}",
+        colcon_command,
         stdout=sys.stdout,
         stderr=sys.stderr,
         shell=True,
@@ -124,22 +157,28 @@ if __name__ == "__main__":
     returncode = command.returncode
 
     build_folder = build_folder or "build"
-    if len(packages) > 0:
-        for package in packages:
-            print_info(f">>> {package}")
+    if not args.list_tests:
+        if len(packages) > 0:
+            for package in packages:
+                print_info(f">>> {package}")
+                command = subprocess.run(
+                    f"colcon test-result --verbose --test-result-base {build_folder}/{package}",
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    shell=True,
+                )
+                returncode |= command.returncode
+        else:
             command = subprocess.run(
-                f"colcon test-result --verbose --test-result-base {build_folder}/{package}",
+                f"colcon test-result --verbose --test-result-base {build_folder}",
                 stdout=sys.stdout,
                 stderr=sys.stderr,
                 shell=True,
             )
             returncode |= command.returncode
-    else:
-        command = subprocess.run(
-            f"colcon test-result --verbose --test-result-base {build_folder}",
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            shell=True,
-        )
-        returncode |= command.returncode
+
     sys.exit(returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -9,6 +9,7 @@ from tuda_workspace_scripts.workspace import *
 import argcomplete
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 
@@ -17,7 +18,7 @@ def main():
     workspace_root = get_workspace_root()
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     packages_arg = parser.add_argument(
-        "packages", nargs="*", help="If specified only these packages are built."
+        "packages", nargs="*", help="If specified only these packages are tested."
     )
     packages_arg.completer = PackageChoicesCompleter(workspace_root)
     parser.add_argument(
@@ -74,6 +75,10 @@ def main():
     if workspace_root is None:
         print_workspace_error()
         exit()
+
+    if args.list_tests and args.filter:
+        print_error("--list-tests and --filter cannot be combined.")
+        sys.exit(1)
 
     packages = args.packages or []
     if args.this:
@@ -148,15 +153,20 @@ def main():
         colcon_test_args.extend(["--pytest-args", " --collect-only"])
         colcon_test_args.extend(["--event-handlers", "console_direct+"])
     elif args.filter:
-        colcon_test_args.extend(["--ctest-args", f" -R {args.filter}"])
-        colcon_test_args.extend(["--pytest-args", f" -k {args.filter}"])
+        # Leading space on -R / -k avoids colcon parsing them as its own args.
+        # The filter value is a separate element so it survives as a single
+        # token when forwarded to ctest/pytest, even if it contains spaces.
+        colcon_test_args.extend(["--ctest-args", " -R", args.filter])
+        colcon_test_args.extend(["--pytest-args", " -k", args.filter])
 
     if not args.list_tests:
         print_info(">>> Cleaning old test results")
         clean_test_results(workspace_root, packages, build_folder)
 
+    quoted_colcon_test_args = " ".join(shlex.quote(arg) for arg in colcon_test_args)
     colcon_command = (
-        f". {install_folder}/setup.sh && colcon test {' '.join(colcon_test_args)}"
+        f". {shlex.quote(os.path.join(install_folder, 'setup.sh'))}"
+        f" && colcon test {quoted_colcon_test_args}"
     )
     print_info(f">>> Command: {colcon_command}")
     command = subprocess.run(
@@ -167,7 +177,6 @@ def main():
     )
     returncode = command.returncode
 
-    build_folder = build_folder or "build"
     if not args.list_tests:
         if len(packages) > 0:
             for package in packages:

--- a/tuda_workspace_scripts/build.py
+++ b/tuda_workspace_scripts/build.py
@@ -143,6 +143,20 @@ def clean_packages(
         os.chdir(original_path)
 
 
+def clean_test_results(workspace_root, packages, build_base="build"):
+    for package in packages:
+        package_build_dir = os.path.join(workspace_root, build_base, package)
+        if not os.path.isdir(package_build_dir):
+            continue
+        for root, dirs, files in os.walk(package_build_dir, topdown=True):
+            if "test_results" in dirs:
+                shutil.rmtree(os.path.join(root, "test_results"))
+                dirs.remove("test_results")
+            for file in files:
+                if file.endswith(".xml"):
+                    os.remove(os.path.join(root, file))
+
+
 # docker run --rm -it -v ~/workspaces/noetic/src:/workspace/src:ro -v /tmp/install:/workspace/install:rw --env ROS_DISTRO=noetic --platform arm64 cross-compile-arm64 workspace_scripts
 
 

--- a/tuda_workspace_scripts/build.py
+++ b/tuda_workspace_scripts/build.py
@@ -144,11 +144,29 @@ def clean_packages(
 
 
 def clean_test_results(workspace_root, packages, build_base="build"):
-    for package in packages:
-        package_build_dir = os.path.join(workspace_root, build_base, package)
+    """Remove stale ``test_results/`` subtrees under each package's build dir.
+
+    If ``packages`` is empty, every package directory under ``build_base`` is
+    cleaned.
+    """
+    build_base_dir = os.path.join(workspace_root, build_base)
+    if any(packages):
+        package_build_dirs = [
+            os.path.join(build_base_dir, package) for package in packages
+        ]
+    elif os.path.isdir(build_base_dir):
+        package_build_dirs = [
+            os.path.join(build_base_dir, entry)
+            for entry in os.listdir(build_base_dir)
+            if os.path.isdir(os.path.join(build_base_dir, entry))
+        ]
+    else:
+        package_build_dirs = []
+
+    for package_build_dir in package_build_dirs:
         if not os.path.isdir(package_build_dir):
             continue
-        for root, dirs, files in os.walk(package_build_dir, topdown=True):
+        for root, dirs, _ in os.walk(package_build_dir, topdown=True):
             if "test_results" in dirs:
                 shutil.rmtree(os.path.join(root, "test_results"))
                 dirs.remove("test_results")

--- a/tuda_workspace_scripts/build.py
+++ b/tuda_workspace_scripts/build.py
@@ -152,9 +152,6 @@ def clean_test_results(workspace_root, packages, build_base="build"):
             if "test_results" in dirs:
                 shutil.rmtree(os.path.join(root, "test_results"))
                 dirs.remove("test_results")
-            for file in files:
-                if file.endswith(".xml"):
-                    os.remove(os.path.join(root, file))
 
 
 # docker run --rm -it -v ~/workspaces/noetic/src:/workspace/src:ro -v /tmp/install:/workspace/install:rw --env ROS_DISTRO=noetic --platform arm64 cross-compile-arm64 workspace_scripts


### PR DESCRIPTION
Adds option to list tests with `--list-tests` and to only run specific tests with `--filter` (note that you have to use the syntax of the filtering based on whether it's pytest or ctest).
This also ensures that old test results are cleaned before running the tests, preventing them from appearing in the output (e.g., if a test was removed or if using `--filter`, only a specific test was run).