### PR TITLE
Dev/zenoh bridge

### DIFF
--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -2,7 +2,6 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
 import argcomplete
-import os
 from tuda_workspace_scripts.discovery import *
 from tuda_workspace_scripts.print import *
 from tuda_workspace_scripts.robots import *
@@ -25,14 +24,6 @@ class RobotChoicesCompleter:
             complete_args = list(filter(lambda x: x not in chosen_args, complete_args))
 
         return complete_args
-
-
-def _has_discovery_endpoints(
-    selected_robots: list[str], custom_addresses: list[str]
-) -> bool:
-    if custom_addresses:
-        return True
-    return any(robot != "off" for robot in selected_robots)
 
 
 def main():
@@ -136,16 +127,9 @@ Examples: hostname 10.0.10.3
             )
         elif hook.endswith(".bash") or hook.endswith(".sh"):
             executable = "bash" if hook.endswith(".bash") else "sh"
-            hook_env = os.environ.copy()
-            hook_env["TUDA_WSS_DISCOVERY_HAS_ENDPOINTS"] = (
-                "1"
-                if _has_discovery_endpoints(selected_robots, custom_addresses)
-                else "0"
-            )
             subprocess.run(
                 [executable, hook] + selected_robots + custom_addresses,
                 cwd=get_workspace_root(),
-                env=hook_env,
             )
 
     print_info("Discovery configuration updated.")

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -2,6 +2,7 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
 import argcomplete
+import os
 from tuda_workspace_scripts.discovery import *
 from tuda_workspace_scripts.print import *
 from tuda_workspace_scripts.robots import *
@@ -24,6 +25,14 @@ class RobotChoicesCompleter:
             complete_args = list(filter(lambda x: x not in chosen_args, complete_args))
 
         return complete_args
+
+
+def _has_discovery_endpoints(
+    selected_robots: list[str], custom_addresses: list[str]
+) -> bool:
+    if custom_addresses:
+        return True
+    return any(robot != "off" for robot in selected_robots)
 
 
 def main():
@@ -127,9 +136,16 @@ Examples: hostname 10.0.10.3
             )
         elif hook.endswith(".bash") or hook.endswith(".sh"):
             executable = "bash" if hook.endswith(".bash") else "sh"
+            hook_env = os.environ.copy()
+            hook_env["TUDA_WSS_DISCOVERY_HAS_ENDPOINTS"] = (
+                "1"
+                if _has_discovery_endpoints(selected_robots, custom_addresses)
+                else "0"
+            )
             subprocess.run(
                 [executable, hook] + selected_robots + custom_addresses,
                 cwd=get_workspace_root(),
+                env=hook_env,
             )
 
     print_info("Discovery configuration updated.")

--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -16,9 +16,13 @@ if not ws_root:
 RMW: str | None = os.getenv("RMW_IMPLEMENTATION", None)
 CYCLONEDDS_URI: str | None = os.getenv("CYCLONEDDS_URI", None)
 ZENOH_ROUTER_CONFIG_PATH: str | None = os.getenv("ZENOH_ROUTER_CONFIG_URI", None)
+ZENOH_BRIDGE_CONFIG_PATH: str | None = os.getenv("ZENOH_BRIDGE_CONFIG_URI", None)
 XML_MARKER = "<!-- This file is managed by tuda_workspace_scripts. Changes may be overwritten. -->"
 YAML_MARKER = (
     "# This file is managed by tuda_workspace_scripts. Changes may be overwritten."
+)
+JSON_COMMENT_MARKER = (
+    "// This file is managed by tuda_workspace_scripts. Changes may be overwritten."
 )
 
 
@@ -30,9 +34,8 @@ def create_discovery_config(selected_robots: list[str], custom_addresses: list[s
             selected_robots, available_robots, custom_addresses
         )
     elif RMW == "rmw_cyclonedds_cpp":
-        create_cyclonedds_router_config_xml(
-            selected_robots, available_robots, custom_addresses
-        )
+        create_static_cyclonedds_config_xml()
+        create_zenoh_bridge_config(selected_robots, available_robots, custom_addresses)
     elif RMW:
         raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
     else:
@@ -45,12 +48,8 @@ def update_discovery_config(selected_robots: list[str], custom_addresses: list[s
     if RMW == "rmw_zenoh_cpp":
         update_zenoh_router_config(selected_robots, available_robots, custom_addresses)
     elif RMW == "rmw_cyclonedds_cpp":
-        print_warn(
-            "Updating Cyclone DDS config is not supported. Overwriting the config file instead."
-        )
-        create_cyclonedds_router_config_xml(
-            selected_robots, available_robots, custom_addresses
-        )
+        create_static_cyclonedds_config_xml()
+        update_zenoh_bridge_config(selected_robots, available_robots, custom_addresses)
     elif RMW:
         raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
     else:
@@ -70,12 +69,145 @@ def get_connected_robots() -> list[str]:
                 ):
                     connected_robots.append(robot_name)
         return connected_robots
+    elif RMW == "rmw_cyclonedds_cpp":
+        if not ZENOH_BRIDGE_CONFIG_PATH or not os.path.isfile(ZENOH_BRIDGE_CONFIG_PATH):
+            return []
+        routers = get_zenoh_routers_from_config_file(ZENOH_BRIDGE_CONFIG_PATH)
+        connected_robots = []
+        for router in routers:
+            for robot_name, robot_data in available_robots.items():
+                if any(
+                    router.get_zenoh_router_address() == r.get_zenoh_router_address()
+                    for r in robot_data.zenoh_routers
+                ):
+                    connected_robots.append(robot_name)
+        return connected_robots
     elif RMW:
         raise NotImplementedError(
             f"Listing the currently connected robots is not implemented for RMW {RMW}"
         )
     else:
         raise RuntimeError("RMW_IMPLEMENTATION is not set.")
+
+
+def create_static_cyclonedds_config_xml():
+    """Create the static CycloneDDS config with only localhost as peer.
+    When using rmw_cyclonedds_cpp with a zenoh bridge, CycloneDDS only communicates
+    locally and the bridge handles remote communication.
+    """
+    if not CYCLONEDDS_URI:
+        print_warn("CYCLONEDDS_URI is not set. Cannot write Cyclone DDS config.")
+        return
+
+    config = _create_cyclonedds_config_xml(["127.0.0.1"])
+
+    if os.path.isfile(CYCLONEDDS_URI):
+        with open(CYCLONEDDS_URI, "r") as file:
+            if file.readline().strip() != XML_MARKER:
+                i = 0
+                while os.path.isfile(CYCLONEDDS_URI + f".backup{i}"):
+                    i += 1
+                print_warn(
+                    f"Existing cyclonedds config found at {CYCLONEDDS_URI}. Backing up as {CYCLONEDDS_URI}.backup{i}."
+                )
+                os.rename(CYCLONEDDS_URI, f"{CYCLONEDDS_URI}.backup{i}")
+
+    with open(CYCLONEDDS_URI, "w", encoding="utf-8") as file:
+        file.write(f"{XML_MARKER}\n")
+        file.write(config)
+    print_info("Cyclone DDS config updated.")
+
+
+def create_zenoh_bridge_config(
+    selected_robots: list[str],
+    available_robots: dict[str, Robot],
+    custom_addresses: list[str],
+):
+    if not ZENOH_BRIDGE_CONFIG_PATH:
+        print_warn(
+            "ZENOH_BRIDGE_CONFIG_URI is not set. Cannot write zenoh bridge config."
+        )
+        return
+    if not ZENOH_BRIDGE_CONFIG_PATH.endswith((".json", ".json5")):
+        print_warn(
+            f"Unsupported config file format: {ZENOH_BRIDGE_CONFIG_PATH}. Supported formats are .json and .json5."
+        )
+        return
+
+    routers = _create_zenoh_router_list(
+        selected_robots, available_robots, custom_addresses
+    )
+    config = _create_zenoh_bridge_config_dict(routers)
+
+    if os.path.isfile(ZENOH_BRIDGE_CONFIG_PATH):
+        with open(ZENOH_BRIDGE_CONFIG_PATH, "r") as file:
+            if file.readline().strip() != JSON_COMMENT_MARKER:
+                i = 0
+                while os.path.isfile(ZENOH_BRIDGE_CONFIG_PATH + f".backup{i}"):
+                    i += 1
+                print_warn(
+                    f"Existing zenoh bridge config found at {ZENOH_BRIDGE_CONFIG_PATH}. Backing up as {ZENOH_BRIDGE_CONFIG_PATH}.backup{i}."
+                )
+                os.rename(
+                    ZENOH_BRIDGE_CONFIG_PATH, f"{ZENOH_BRIDGE_CONFIG_PATH}.backup{i}"
+                )
+
+    with open(ZENOH_BRIDGE_CONFIG_PATH, "w") as file:
+        file.write(f"{JSON_COMMENT_MARKER}\n")
+        json5.dump(config, file, indent=2)
+    print_info("Zenoh bridge config updated.")
+
+
+def update_zenoh_bridge_config(
+    selected_robots: list[str],
+    available_robots: dict[str, Robot],
+    custom_addresses: list[str],
+):
+    if not ZENOH_BRIDGE_CONFIG_PATH:
+        print_warn(
+            "ZENOH_BRIDGE_CONFIG_URI is not set. Cannot update zenoh bridge config."
+        )
+        return
+    if not ZENOH_BRIDGE_CONFIG_PATH.endswith((".json", ".json5")):
+        print_warn(
+            f"Unsupported config file format: {ZENOH_BRIDGE_CONFIG_PATH}. Supported formats are .json and .json5."
+        )
+        return
+
+    routers = _create_zenoh_router_list(
+        selected_robots, available_robots, custom_addresses
+    )
+
+    config = _create_zenoh_bridge_config_dict(routers)
+    if not os.path.isfile(ZENOH_BRIDGE_CONFIG_PATH):
+        print_warn(
+            f"Zenoh bridge config file not found at {ZENOH_BRIDGE_CONFIG_PATH}. Creating new config file."
+        )
+    else:
+        with open(ZENOH_BRIDGE_CONFIG_PATH, "r") as file:
+            existing = json5.load(file)
+        # Preserve user settings, only update connect endpoints
+        existing.setdefault("connect", {})["endpoints"] = [
+            router.get_zenoh_router_address() for router in routers
+        ]
+        config = existing
+
+    with open(ZENOH_BRIDGE_CONFIG_PATH, "w") as file:
+        file.write(f"{JSON_COMMENT_MARKER}\n")
+        json5.dump(config, file, indent=2)
+    print_info("Zenoh bridge config updated.")
+
+
+def _create_zenoh_bridge_config_dict(routers: list[ZenohRouter]) -> dict:
+    return {
+        "mode": "router",
+        "listen": {"endpoints": ["tcp/0.0.0.0:7448"]},
+        "connect": {
+            "endpoints": [router.get_zenoh_router_address() for router in routers]
+        },
+        "scouting": {"multicast": {"enabled": False}},
+        "plugins": {"ros2dds": {"domain": 0}},
+    }
 
 
 def create_cyclonedds_router_config_xml(
@@ -291,6 +423,7 @@ def print_discovery_config():
     if RMW == "rmw_zenoh_cpp":
         print_zenoh_discovery_config()
     elif RMW == "rmw_cyclonedds_cpp":
+        print_zenoh_bridge_discovery_config()
         print_cyclonedds_discovery_config()
     elif RMW:
         raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
@@ -314,6 +447,20 @@ def print_zenoh_discovery_config():
             print(file.read())
     else:
         print_warn(f"Configuration file not found: {ZENOH_ROUTER_CONFIG_PATH}")
+
+
+def print_zenoh_bridge_discovery_config():
+    if not ZENOH_BRIDGE_CONFIG_PATH:
+        print_warn("ZENOH_BRIDGE_CONFIG_URI is not set.")
+        return
+    if os.path.exists(ZENOH_BRIDGE_CONFIG_PATH):
+        print_info(f"Zenoh bridge configuration file: {ZENOH_BRIDGE_CONFIG_PATH}")
+        with open(ZENOH_BRIDGE_CONFIG_PATH, "r") as file:
+            print(file.read())
+    else:
+        print_warn(
+            f"Zenoh bridge configuration file not found: {ZENOH_BRIDGE_CONFIG_PATH}"
+        )
 
 
 def _create_zenoh_router_config_yaml(routers):

--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -35,7 +35,10 @@ def create_discovery_config(selected_robots: list[str], custom_addresses: list[s
         )
     elif RMW == "rmw_cyclonedds_cpp":
         create_static_cyclonedds_config_xml()
-        create_zenoh_bridge_config(selected_robots, available_robots, custom_addresses)
+        if ZENOH_BRIDGE_CONFIG_PATH:
+            create_zenoh_bridge_config(
+                selected_robots, available_robots, custom_addresses
+            )
     elif RMW:
         raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
     else:
@@ -49,7 +52,10 @@ def update_discovery_config(selected_robots: list[str], custom_addresses: list[s
         update_zenoh_router_config(selected_robots, available_robots, custom_addresses)
     elif RMW == "rmw_cyclonedds_cpp":
         create_static_cyclonedds_config_xml()
-        update_zenoh_bridge_config(selected_robots, available_robots, custom_addresses)
+        if ZENOH_BRIDGE_CONFIG_PATH:
+            update_zenoh_bridge_config(
+                selected_robots, available_robots, custom_addresses
+            )
     elif RMW:
         raise NotImplementedError(f"Discovery is not implemented for RMW {RMW}")
     else:

--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -101,21 +101,10 @@ def create_static_cyclonedds_config_xml():
 
     config = _create_cyclonedds_config_xml(["127.0.0.1"])
 
-    if os.path.isfile(CYCLONEDDS_URI):
-        with open(CYCLONEDDS_URI, "r") as file:
-            if file.readline().strip() != XML_MARKER:
-                i = 0
-                while os.path.isfile(CYCLONEDDS_URI + f".backup{i}"):
-                    i += 1
-                print_warn(
-                    f"Existing cyclonedds config found at {CYCLONEDDS_URI}. Backing up as {CYCLONEDDS_URI}.backup{i}."
-                )
-                os.rename(CYCLONEDDS_URI, f"{CYCLONEDDS_URI}.backup{i}")
-
     with open(CYCLONEDDS_URI, "w", encoding="utf-8") as file:
         file.write(f"{XML_MARKER}\n")
         file.write(config)
-    print_info("Cyclone DDS config updated.")
+    print_info("Cyclone DDS static config written.")
 
 
 def create_zenoh_bridge_config(

--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -34,7 +34,6 @@ def create_discovery_config(selected_robots: list[str], custom_addresses: list[s
             selected_robots, available_robots, custom_addresses
         )
     elif RMW == "rmw_cyclonedds_cpp":
-        create_static_cyclonedds_config_xml()
         if ZENOH_BRIDGE_CONFIG_PATH:
             create_zenoh_bridge_config(
                 selected_robots, available_robots, custom_addresses
@@ -51,7 +50,6 @@ def update_discovery_config(selected_robots: list[str], custom_addresses: list[s
     if RMW == "rmw_zenoh_cpp":
         update_zenoh_router_config(selected_robots, available_robots, custom_addresses)
     elif RMW == "rmw_cyclonedds_cpp":
-        create_static_cyclonedds_config_xml()
         if ZENOH_BRIDGE_CONFIG_PATH:
             update_zenoh_bridge_config(
                 selected_robots, available_robots, custom_addresses


### PR DESCRIPTION
Adds discovery feature for rmw_cyclonedds_cpp + zenoh-bridge.
It does not break the current zenoh router setup.

The cycloneDDS config is static and remains unchanged -> by default, no operator PCs can communicate with each other.
Inter PC comm is handled by the zenoh bridge. It only runs if endpoints are specified, otherwise it does not.
This has to be explicitly forwarded to the restart hook in hector_workspace_scripts:
`hook_env["TUDA_WSS_DISCOVERY_HAS_ENDPOINTS"]`

Related PRs:

- hector_workspace_scripts
- hector ROS2 workspace