### PR TITLE
Warn if quic config faulty

### DIFF
--- a/tuda_workspace_scripts/discovery.py
+++ b/tuda_workspace_scripts/discovery.py
@@ -149,6 +149,7 @@ def create_zenoh_bridge_config(
         file.write(f"{JSON_COMMENT_MARKER}\n")
         json5.dump(config, file, indent=2)
     print_info("Zenoh bridge config updated.")
+    _warn_if_quic_tls_missing(routers, config)
 
 
 def update_zenoh_bridge_config(
@@ -189,6 +190,26 @@ def update_zenoh_bridge_config(
         file.write(f"{JSON_COMMENT_MARKER}\n")
         json5.dump(config, file, indent=2)
     print_info("Zenoh bridge config updated.")
+    _warn_if_quic_tls_missing(routers, config)
+
+
+def _warn_if_quic_tls_missing(routers: list[ZenohRouter], config: dict):
+    if not any(r.protocol == "quic" for r in routers):
+        return
+    ca_cert = (
+        config.get("transport", {})
+        .get("link", {})
+        .get("tls", {})
+        .get("root_ca_certificate")
+    )
+    if ca_cert is None:
+        print_warn(
+            "QUIC endpoint selected but 'transport.link.tls.root_ca_certificate' is not configured in the zenoh bridge config."
+        )
+    elif not os.path.isfile(ca_cert):
+        print_warn(
+            f"QUIC endpoint selected but TLS root CA certificate not found at '{ca_cert}'."
+        )
 
 
 def _create_zenoh_bridge_config_dict(routers: list[ZenohRouter]) -> dict:

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -93,11 +93,11 @@ class ZenohRouter:
         Creates a ZenohRouter objects from the text representation.
         Supports formats:
         - "protocol/address:port": "tcp/192.168.1.100:7447" or "quic/athena-main:7447"
-        - "address:port": uses default protocol "tcp"
+        - "address:port": uses default protocol "quic"
         - "protocol/address": uses default port 7447
-        - "address": uses default protocol "tcp" and port 7447
+        - "address": uses default protocol "quic" and port 7447
         """
-        protocol = "tcp"
+        protocol = "quic"
         port = 7447
         address = None
 
@@ -238,7 +238,7 @@ def _load_zenoh_router_from_yaml(config: dict[str, Any]) -> ZenohRouter:
         raise ValueError(f"Address not specified for router {config}")
     address = config["address"]
     port = config.get("port", 7447)
-    protocol = config.get("protocol", "tcp")
+    protocol = config.get("protocol", "quic")
     return ZenohRouter(address, port, protocol)
 
 

--- a/tuda_workspace_scripts/robots.py
+++ b/tuda_workspace_scripts/robots.py
@@ -93,11 +93,11 @@ class ZenohRouter:
         Creates a ZenohRouter objects from the text representation.
         Supports formats:
         - "protocol/address:port": "tcp/192.168.1.100:7447" or "quic/athena-main:7447"
-        - "address:port": uses default protocol "quic"
+        - "address:port": uses default protocol "tcp"
         - "protocol/address": uses default port 7447
-        - "address": uses default protocol "quic" and port 7447
+        - "address": uses default protocol "tcp" and port 7447
         """
-        protocol = "quic"
+        protocol = "tcp"
         port = 7447
         address = None
 
@@ -238,7 +238,7 @@ def _load_zenoh_router_from_yaml(config: dict[str, Any]) -> ZenohRouter:
         raise ValueError(f"Address not specified for router {config}")
     address = config["address"]
     port = config.get("port", 7447)
-    protocol = config.get("protocol", "quic")
+    protocol = config.get("protocol", "tcp")
     return ZenohRouter(address, port, protocol)
 
 


### PR DESCRIPTION
Changes the default protocol for zenoh to QUIC. See here: https://tasks.teamhector.de/team-hector/browse/GNRL-787/