### PR TITLE
Look for --ros-args arg in ros zombie process heuristic

### DIFF
--- a/scripts/hooks/wtf/20.kill_zombies.py
+++ b/scripts/hooks/wtf/20.kill_zombies.py
@@ -91,6 +91,8 @@ def _is_ros_zombie_node(cmdline: list[str]) -> bool:
             return True
         if item.startswith("__node:="):
             score += 1
+        if item.find("--ros-args") != -1:
+            score += 1
     return score >= 2
 
 


### PR DESCRIPTION
Hector wtf does not catch all ros zombie processes related to fast-lio & point cloud accumulation started via hector postproc:

<img width="1757" height="526" alt="Screenshot from 2026-07-20 07-56-50" src="https://github.com/user-attachments/assets/d9ab22ea-7a8a-4afd-ac83-b4c2c3f0bc7a" />

This PR proposes a small extension of the ros zombie node detection heuristic which catches these processes:

<img width="707" height="544" alt="Screenshot from 2026-07-20 07-59-41" src="https://github.com/user-attachments/assets/631f4979-b575-427a-9dd4-fa15adeb12a5" />