### PR TITLE
Implement fallback if ros2 daemon stop request times out. Ros2 daemon…

### DIFF
--- a/scripts/hooks/wtf/90.ros2_daemon_restart.py
+++ b/scripts/hooks/wtf/90.ros2_daemon_restart.py
@@ -41,7 +41,7 @@ def fix() -> int:
         try:
             if is_daemon_running(args=[]):
                 print_info("ROS2 daemon is running. Restarting it just to be safe.")
-                if not shutdown_daemon(args=[], timeout=1):
+                if not shutdown_daemon(args=[], timeout=5):
                     if not kill_ros2_daemon():
                         print_error("Failed to shutdown ROS2 daemon")
                         return 0
@@ -60,6 +60,12 @@ def fix() -> int:
             print_warn(
                 "Canceling the restart of the ROS2 daemon might lead to further issues."
             )
-            if confirm("Stop anyway?"):
+            if confirm(
+                "Stop anyway? If ros2 daemon stopping fails, fallback can be enabled."
+            ):
                 raise
             print_info("Okay. Trying again.")
+
+            if confirm("Use fallback to stop daemon?"):
+                if not kill_ros2_daemon():
+                    print_error("Failed to kill ROS2 daemon")

--- a/scripts/hooks/wtf/90.ros2_daemon_restart.py
+++ b/scripts/hooks/wtf/90.ros2_daemon_restart.py
@@ -3,11 +3,12 @@ import psutil
 
 from tuda_workspace_scripts.print import *
 from ros2cli.node.daemon import is_daemon_running, spawn_daemon, shutdown_daemon
-import os
+import asyncio
+
+daemon_timeout = 5  # seconds
 
 
 def find_ros2_daemon() -> int:
-    print_info("ROS2 daemon not responding to shutdown request. Killing it.")
     for proc in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
             cmdline = proc.info["cmdline"]
@@ -35,37 +36,53 @@ def kill_ros2_daemon() -> bool:
         return True
 
 
+async def restart_ros2_daemon() -> int:
+
+    successful_shutdown = False
+    async with asyncio.timeout(daemon_timeout):
+        successful_shutdown = await graceful_daemon_shutdown()
+
+    if not successful_shutdown:
+        print_info("ROS2 daemon not responding to shutdown request. Killing it.")
+        if not kill_ros2_daemon():
+            print_error("Failed to kill ROS2 daemon")
+            return 0
+
+    print_info("Spawning ROS2 daemon.")
+    if not spawn_daemon(args=[], timeout=daemon_timeout):
+        print_error("Failed to start ROS2 daemon")
+        return 0
+
+    print_info("Successfully spawned ROS2 daemon.")
+    # The ros2 daemon not running could have actually been an issue for commands such as ros2 topic/service/action/...
+    return 1
+
+
+async def graceful_daemon_shutdown() -> bool:
+    if is_daemon_running(args=[]):
+        print_info("ROS2 daemon is running. Attempting graceful shutdown.")
+        if not shutdown_daemon(args=[], timeout=daemon_timeout):
+            print_warn("Graceful shutdown failed")
+            return False
+        else:
+            print_info("ROS2 daemon shut down gracefully.")
+            return True
+
+    print_info("ROS2 daemon is not running.")
+    return True  # Daemon was not running, so consider it a success
+
+
 def fix() -> int:
     print_header("Checking ROS2 daemon")
     while True:
         try:
-            if is_daemon_running(args=[]):
-                print_info("ROS2 daemon is running. Restarting it just to be safe.")
-                if not shutdown_daemon(args=[], timeout=5):
-                    if not kill_ros2_daemon():
-                        print_error("Failed to shutdown ROS2 daemon")
-                        return 0
-                if not spawn_daemon(args=[], timeout=10):
-                    print_error("Failed to restart ROS2 daemon after stopping it")
-                    return 0
-                print_info("ROS2 daemon restarted")
-                return 0
-            print_info("ROS2 daemon is not running. Starting it.")
-            if not spawn_daemon(args=[], timeout=10):
-                print_error("Failed to start ROS2 daemon")
-                return 0
-            # The ros2 daemon not running could have actually been an issue for commands such as ros2 topic/service/action/...
-            return 1
+            return asyncio.run(restart_ros2_daemon())
+
         except KeyboardInterrupt:
             print_warn(
                 "Canceling the restart of the ROS2 daemon might lead to further issues."
             )
-            if confirm(
-                "Stop anyway? If ros2 daemon stopping fails, fallback can be enabled."
-            ):
+            if confirm("Stop anyway?"):
                 raise
-            print_info("Okay. Trying again.")
 
-            if confirm("Use fallback to stop daemon?"):
-                if not kill_ros2_daemon():
-                    print_error("Failed to kill ROS2 daemon")
+            print_info("Okay. Trying again.")

--- a/scripts/hooks/wtf/90.ros2_daemon_restart.py
+++ b/scripts/hooks/wtf/90.ros2_daemon_restart.py
@@ -1,7 +1,38 @@
 #!/usr/bin/env python3
+import psutil
+
 from tuda_workspace_scripts.print import *
 from ros2cli.node.daemon import is_daemon_running, spawn_daemon, shutdown_daemon
 import os
+
+
+def find_ros2_daemon() -> int:
+    print_info("ROS2 daemon not responding to shutdown request. Killing it.")
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            cmdline = proc.info["cmdline"]
+            if cmdline and "ros2-daemon" in cmdline:
+                return proc.info["pid"]
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+
+def kill_ros2_daemon() -> int:
+    ros2_daemon_pid = find_ros2_daemon()
+    if ros2_daemon_pid:
+        try:
+            proc = psutil.Process(ros2_daemon_pid)
+            proc.kill()
+            # Make sure the process has terminated and xmlrpc server port is released
+            proc.wait(timeout=1)
+            print_info(f"Killed ROS2 daemon with PID {ros2_daemon_pid}.")
+            return 1
+        except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
+            print_error(f"Failed to kill ROS2 daemon with PID {ros2_daemon_pid}: {e}")
+            return 0
+    else:
+        print_info("No ROS2 daemon process found to kill.")
+        return 1
 
 
 def fix() -> int:
@@ -10,9 +41,10 @@ def fix() -> int:
         try:
             if is_daemon_running(args=[]):
                 print_info("ROS2 daemon is running. Restarting it just to be safe.")
-                if not shutdown_daemon(args=[], timeout=10):
-                    print_error("Failed to shutdown ROS2 daemon")
-                    return 0
+                if not shutdown_daemon(args=[], timeout=1):
+                    if not kill_ros2_daemon():
+                        print_error("Failed to shutdown ROS2 daemon")
+                        return 0
                 if not spawn_daemon(args=[], timeout=10):
                     print_error("Failed to restart ROS2 daemon after stopping it")
                     return 0

--- a/scripts/hooks/wtf/90.ros2_daemon_restart.py
+++ b/scripts/hooks/wtf/90.ros2_daemon_restart.py
@@ -37,8 +37,6 @@ def kill_ros2_daemon() -> bool:
 
 
 async def restart_ros2_daemon() -> int:
-
-    successful_shutdown = False
     try:
         async with asyncio.timeout(daemon_timeout):
             successful_shutdown = await graceful_daemon_shutdown()
@@ -62,7 +60,9 @@ async def restart_ros2_daemon() -> int:
 
 
 async def graceful_daemon_shutdown() -> bool:
-    if is_daemon_running(args=[]):
+    print_info("Checking status of ROS2 daemon.")
+    is_running = await asyncio.to_thread(is_daemon_running, args=[])
+    if is_running:
         print_info("ROS2 daemon is running. Attempting graceful shutdown.")
         if not shutdown_daemon(args=[], timeout=daemon_timeout):
             print_warn("Graceful shutdown failed")

--- a/scripts/hooks/wtf/90.ros2_daemon_restart.py
+++ b/scripts/hooks/wtf/90.ros2_daemon_restart.py
@@ -17,7 +17,7 @@ def find_ros2_daemon() -> int:
             continue
 
 
-def kill_ros2_daemon() -> int:
+def kill_ros2_daemon() -> bool:
     ros2_daemon_pid = find_ros2_daemon()
     if ros2_daemon_pid:
         try:
@@ -26,13 +26,13 @@ def kill_ros2_daemon() -> int:
             # Make sure the process has terminated and xmlrpc server port is released
             proc.wait(timeout=1)
             print_info(f"Killed ROS2 daemon with PID {ros2_daemon_pid}.")
-            return 1
+            return True
         except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
             print_error(f"Failed to kill ROS2 daemon with PID {ros2_daemon_pid}: {e}")
-            return 0
+            return False
     else:
         print_info("No ROS2 daemon process found to kill.")
-        return 1
+        return True
 
 
 def fix() -> int:

--- a/scripts/hooks/wtf/90.ros2_daemon_restart.py
+++ b/scripts/hooks/wtf/90.ros2_daemon_restart.py
@@ -39,8 +39,11 @@ def kill_ros2_daemon() -> bool:
 async def restart_ros2_daemon() -> int:
 
     successful_shutdown = False
-    async with asyncio.timeout(daemon_timeout):
-        successful_shutdown = await graceful_daemon_shutdown()
+    try:
+        async with asyncio.timeout(daemon_timeout):
+            successful_shutdown = await graceful_daemon_shutdown()
+    except TimeoutError:
+        successful_shutdown = False
 
     if not successful_shutdown:
         print_info("ROS2 daemon not responding to shutdown request. Killing it.")


### PR DESCRIPTION
… process will be killed directly.

I recently started encountering the issue of the ros2 daemon being frozen. Shutdown request will timeout as well. Therefore this PR introduces a fallback to the wtf script that kills the daemon process directly if shutdown fails before attempting a restart.